### PR TITLE
feat(core): 段评章节识别与 EPUB 解析增强

### DIFF
--- a/core/src/epub/chapter.rs
+++ b/core/src/epub/chapter.rs
@@ -10,6 +10,18 @@ pub enum InlineStyle {
     BoldItalic,
 }
 
+impl InlineStyle {
+    /// Stable string representation for cross-platform serialization.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            InlineStyle::Normal => "Normal",
+            InlineStyle::Bold => "Bold",
+            InlineStyle::Italic => "Italic",
+            InlineStyle::BoldItalic => "BoldItalic",
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, Default, PartialEq)]
 pub enum CorrectionStatus {
     #[default]
@@ -45,9 +57,13 @@ pub enum ContentBlock {
     Heading {
         level: u8,
         spans: Vec<TextSpan>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        anchor_id: Option<String>,
     },
     Paragraph {
         spans: Vec<TextSpan>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        anchor_id: Option<String>,
     },
     Image {
         data: Arc<Vec<u8>>,

--- a/core/src/epub/parser/html.rs
+++ b/core/src/epub/parser/html.rs
@@ -19,7 +19,8 @@ pub(super) fn parse_html_blocks(
         .unwrap_or_else(|| document.root_element());
 
     let mut blocks = Vec::new();
-    collect_blocks(start_elem, &mut blocks, chapter_path, image_resources);
+    let mut no_id = None;
+    collect_blocks(start_elem, &mut blocks, chapter_path, image_resources, &mut no_id);
 
     while matches!(blocks.first(), Some(ContentBlock::BlankLine)) {
         blocks.remove(0);
@@ -36,6 +37,7 @@ fn collect_blocks(
     blocks: &mut Vec<ContentBlock>,
     chapter_path: &str,
     image_resources: &HashMap<String, Vec<u8>>,
+    inherited_id: &mut Option<String>,
 ) {
     for child in parent.children() {
         match child.value() {
@@ -45,31 +47,64 @@ fn collect_blocks(
                     match tag {
                         "p" | "figcaption" | "cite" => {
                             let spans = collect_spans(elem_ref, InlineStyle::Normal, None);
+                            let anchor_id = elem
+                                .attr("id")
+                                .map(|s| s.to_string())
+                                .or_else(|| inherited_id.take());
                             if has_visible_text(&spans) {
-                                blocks.push(ContentBlock::Paragraph { spans });
+                                blocks.push(ContentBlock::Paragraph { spans, anchor_id });
+                            } else if anchor_id.is_some() {
+                                // Keep empty paragraph if it has an anchor id (e.g. review placeholder)
+                                blocks.push(ContentBlock::Paragraph { spans, anchor_id });
                             }
                         }
                         "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => {
                             let level = (tag.as_bytes()[1] - b'0').clamp(1, 6);
                             let spans = collect_spans(elem_ref, InlineStyle::Bold, None);
+                            let anchor_id = elem
+                                .attr("id")
+                                .map(|s| s.to_string())
+                                .or_else(|| inherited_id.take());
                             if has_visible_text(&spans) {
-                                blocks.push(ContentBlock::Heading { level, spans });
+                                blocks.push(ContentBlock::Heading { level, spans, anchor_id });
+                            } else if anchor_id.is_some() {
+                                blocks.push(ContentBlock::Heading { level, spans, anchor_id });
                             }
                         }
                         "hr" => blocks.push(ContentBlock::Separator),
                         "br" => blocks.push(ContentBlock::BlankLine),
                         "div" | "section" | "article" | "main" | "body" | "html" | "nav"
                         | "header" | "footer" | "aside" => {
-                            collect_blocks(elem_ref, blocks, chapter_path, image_resources);
+                            let mut container_id = elem.attr("id").map(|s| s.to_string());
+                            collect_blocks(
+                                elem_ref,
+                                blocks,
+                                chapter_path,
+                                image_resources,
+                                &mut container_id,
+                            );
                         }
                         "ul" | "ol" => {
-                            collect_list(elem_ref, blocks, tag == "ol");
+                            let mut list_id = elem.attr("id").map(|s| s.to_string());
+                            collect_list(elem_ref, blocks, tag == "ol", &mut list_id);
                         }
                         "blockquote" => {
                             let mut inner = Vec::new();
-                            collect_blocks(elem_ref, &mut inner, chapter_path, image_resources);
+                            // Use blockquote's own id if present, otherwise consume the
+                            // inherited id so it attaches to the first visible content inside.
+                            let mut bq_id = elem
+                                .attr("id")
+                                .map(|s| s.to_string())
+                                .or_else(|| inherited_id.take());
+                            collect_blocks(
+                                elem_ref,
+                                &mut inner,
+                                chapter_path,
+                                image_resources,
+                                &mut bq_id,
+                            );
                             for block in inner {
-                                if let ContentBlock::Paragraph { mut spans } = block {
+                                if let ContentBlock::Paragraph { mut spans, anchor_id } = block {
                                     spans.insert(
                                         0,
                                         TextSpan {
@@ -79,7 +114,7 @@ fn collect_blocks(
                                             correction: None,
                                         },
                                     );
-                                    blocks.push(ContentBlock::Paragraph { spans });
+                                    blocks.push(ContentBlock::Paragraph { spans, anchor_id });
                                 } else {
                                     blocks.push(block);
                                 }
@@ -88,6 +123,10 @@ fn collect_blocks(
                         "pre" | "code" => {
                             let text = elem_ref.text().collect::<String>();
                             if !text.trim().is_empty() {
+                                let anchor_id = elem
+                                    .attr("id")
+                                    .map(|s| s.to_string())
+                                    .or_else(|| inherited_id.take());
                                 blocks.push(ContentBlock::Paragraph {
                                     spans: vec![TextSpan {
                                         text,
@@ -95,11 +134,13 @@ fn collect_blocks(
                                         link_url: None,
                                         correction: None,
                                     }],
+                                    anchor_id,
                                 });
                             }
                         }
                         "table" => {
-                            collect_table(elem_ref, blocks);
+                            let mut table_id = elem.attr("id").map(|s| s.to_string());
+                            collect_table(elem_ref, blocks, &mut table_id);
                         }
                         "script" | "style" | "meta" | "link" | "title" | "head" => {}
                         "img" | "image" => {
@@ -126,7 +167,8 @@ fn collect_blocks(
                                 if let Some(data) =
                                     resolve_image_data(src, chapter_path, image_resources)
                                 {
-                                    let alt = img_node.value().attr("alt").map(|s| s.to_string());
+                                    let alt =
+                                        img_node.value().attr("alt").map(|s| s.to_string());
                                     blocks.push(ContentBlock::Image { data, alt });
                                 }
                             }
@@ -156,11 +198,22 @@ fn collect_blocks(
                                 }
                             });
                             if has_block_children {
-                                collect_blocks(elem_ref, blocks, chapter_path, image_resources);
+                                let mut fallback_id = elem.attr("id").map(|s| s.to_string());
+                                collect_blocks(
+                                    elem_ref,
+                                    blocks,
+                                    chapter_path,
+                                    image_resources,
+                                    &mut fallback_id,
+                                );
                             } else {
                                 let spans = collect_spans(elem_ref, InlineStyle::Normal, None);
+                                let anchor_id = elem
+                                    .attr("id")
+                                    .map(|s| s.to_string())
+                                    .or_else(|| inherited_id.take());
                                 if has_visible_text(&spans) {
-                                    blocks.push(ContentBlock::Paragraph { spans });
+                                    blocks.push(ContentBlock::Paragraph { spans, anchor_id });
                                 }
                             }
                         }
@@ -170,6 +223,7 @@ fn collect_blocks(
             scraper::Node::Text(text) => {
                 let s = text.trim();
                 if !s.is_empty() {
+                    let anchor_id = inherited_id.take();
                     blocks.push(ContentBlock::Paragraph {
                         spans: vec![TextSpan {
                             text: s.to_string(),
@@ -177,6 +231,7 @@ fn collect_blocks(
                             link_url: None,
                             correction: None,
                         }],
+                        anchor_id,
                     });
                 }
             }
@@ -246,7 +301,12 @@ fn collect_spans(
     spans
 }
 
-fn collect_list(parent: ElementRef, blocks: &mut Vec<ContentBlock>, ordered: bool) {
+fn collect_list(
+    parent: ElementRef,
+    blocks: &mut Vec<ContentBlock>,
+    ordered: bool,
+    inherited_id: &mut Option<String>,
+) {
     let mut index = 1;
     for child in parent.children() {
         if let scraper::Node::Element(elem) = child.value() {
@@ -266,7 +326,8 @@ fn collect_list(parent: ElementRef, blocks: &mut Vec<ContentBlock>, ordered: boo
                     }];
                     spans.extend(collect_spans(li_ref, InlineStyle::Normal, None));
                     if spans.len() > 1 {
-                        blocks.push(ContentBlock::Paragraph { spans });
+                        let anchor_id = inherited_id.take();
+                        blocks.push(ContentBlock::Paragraph { spans, anchor_id });
                     }
                     index += 1;
                 }
@@ -275,7 +336,11 @@ fn collect_list(parent: ElementRef, blocks: &mut Vec<ContentBlock>, ordered: boo
     }
 }
 
-fn collect_table(parent: ElementRef, blocks: &mut Vec<ContentBlock>) {
+fn collect_table(
+    parent: ElementRef,
+    blocks: &mut Vec<ContentBlock>,
+    inherited_id: &mut Option<String>,
+) {
     let row_sel = Selector::parse("tr").expect("valid selector");
     for row in parent.select(&row_sel) {
         let mut row_spans = Vec::new();
@@ -303,7 +368,11 @@ fn collect_table(parent: ElementRef, blocks: &mut Vec<ContentBlock>) {
             }
         }
         if has_visible_text(&row_spans) {
-            blocks.push(ContentBlock::Paragraph { spans: row_spans });
+            let anchor_id = inherited_id.take();
+            blocks.push(ContentBlock::Paragraph {
+                spans: row_spans,
+                anchor_id,
+            });
         }
     }
 }

--- a/core/src/epub/parser/mod.rs
+++ b/core/src/epub/parser/mod.rs
@@ -2,12 +2,12 @@
 mod html;
 mod image;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use epub::doc::EpubDoc;
 
-use super::{Chapter, TocEntry};
+use super::{Chapter, ContentBlock, TocEntry};
 use html::parse_html_blocks;
 use image::load_referenced_images;
 
@@ -20,6 +20,12 @@ pub struct EpubBook {
     pub cover_data: Option<Vec<u8>>,
     #[serde(skip)]
     pub fonts: Vec<(String, Vec<u8>)>,
+    /// Mapping from main chapter index to its review chapter index.
+    #[serde(default)]
+    pub chapter_reviews: HashMap<usize, usize>,
+    /// Set of chapter indices that are review chapters.
+    #[serde(default)]
+    pub review_chapter_indices: HashSet<usize>,
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
@@ -135,11 +141,14 @@ impl EpubBook {
                     .map(|(label, _)| label.clone())
                     .unwrap_or_else(|| format!("第 {} 章", chapters.len() + 1));
 
-                if blocks.is_empty() {
-                    continue;
-                }
-
                 let chapter_idx = chapters.len();
+
+                // Avoid completely empty chapters (keeps index stable but shows something)
+                let blocks = if blocks.is_empty() {
+                    vec![ContentBlock::BlankLine]
+                } else {
+                    blocks
+                };
 
                 chapters.push(Chapter {
                     title: chapter_title.clone(),
@@ -193,12 +202,36 @@ impl EpubBook {
             }
         }
 
+        // Identify review chapters (段评) and build mapping
+        let mut chapter_reviews = HashMap::new();
+        let mut review_chapter_indices = HashSet::new();
+        const REVIEW_SUFFIX: &str = " - 段评";
+        for (idx, ch) in chapters.iter().enumerate() {
+            if ch.title.ends_with(REVIEW_SUFFIX) {
+                review_chapter_indices.insert(idx);
+                let base_title = &ch.title[..ch.title.len() - REVIEW_SUFFIX.len()];
+                // Match to the Nth main chapter with the same title
+                let review_count = chapters[..idx].iter().filter(|c| c.title == ch.title).count();
+                if let Some(main_idx) = chapters
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, c)| c.title == base_title)
+                    .nth(review_count)
+                    .map(|(i, _)| i)
+                {
+                    chapter_reviews.insert(main_idx, idx);
+                }
+            }
+        }
+
         Ok(EpubBook {
             title,
             chapters,
             toc,
             cover_data,
             fonts,
+            chapter_reviews,
+            review_chapter_indices,
         })
     }
 

--- a/core/src/export.rs
+++ b/core/src/export.rs
@@ -124,16 +124,30 @@ fn build_chapter_xhtml(
         };
 
         match block {
-            ContentBlock::Heading { level, spans } => {
+            ContentBlock::Heading { level, spans, anchor_id } => {
                 let tag = format!("h{}", level.min(&6));
-                html.push_str(&format!("<{tag}>"));
+                if let Some(id) = anchor_id {
+                    html.push_str(&format!(
+                        "<{tag} id=\"{}\">",
+                        crate::escape_html(id)
+                    ));
+                } else {
+                    html.push_str(&format!("<{tag}>"));
+                }
                 for span in spans {
                     html.push_str(&crate::escape_html(&span.text));
                 }
                 html.push_str(&format!("</{tag}>\n"));
             }
-            ContentBlock::Paragraph { spans } => {
-                html.push_str("<p>");
+            ContentBlock::Paragraph { spans, anchor_id } => {
+                if let Some(id) = anchor_id {
+                    html.push_str(&format!(
+                        "<p id=\"{}\">",
+                        crate::escape_html(id)
+                    ));
+                } else {
+                    html.push_str("<p>");
+                }
                 if let Some(hl) = highlight {
                     html.push_str(&format!("<span class=\"{}\">", hl.color.css_class()));
                 }

--- a/core/src/i18n/en.json
+++ b/core/src/i18n/en.json
@@ -149,6 +149,8 @@
   "nav.reading_settings": "Reading Settings",
   "nav.prev_chapter": "Previous Chapter",
   "nav.next_chapter": "Next Chapter",
+  "reader.at_first_chapter": "Already at the beginning",
+  "reader.at_last_chapter": "Already at the end",
   "nav.scroll_mode": "Scroll Mode",
   "nav.page_mode": "Page Mode",
   "nav.dark_mode": "Dark Mode",
@@ -347,5 +349,6 @@
   "settings.csc_settings": "Chinese Spell Check",
   "settings.csc_mode": "Correction Mode",
   "settings.csc_threshold": "Threshold",
-  "settings.chars": "chars"
+  "settings.chars": "chars",
+  "review.panel_title": "Paragraph Reviews"
 }

--- a/core/src/i18n/zh_cn.json
+++ b/core/src/i18n/zh_cn.json
@@ -149,6 +149,8 @@
   "nav.reading_settings": "阅读设置",
   "nav.prev_chapter": "上一章",
   "nav.next_chapter": "下一章",
+  "reader.at_first_chapter": "已到开头",
+  "reader.at_last_chapter": "已到末尾",
   "nav.scroll_mode": "滚动模式",
   "nav.page_mode": "翻页模式",
   "nav.dark_mode": "夜间模式",
@@ -347,5 +349,6 @@
   "settings.csc_settings": "中文纠错",
   "settings.csc_mode": "纠错模式",
   "settings.csc_threshold": "纠错力度",
-  "settings.chars": "字符"
+  "settings.chars": "字符",
+  "review.panel_title": "段评"
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -19,20 +19,34 @@ pub fn now_secs() -> u64 {
 }
 
 /// Sanitize a string for use as a filename, with length limit.
+/// Rejects path separators, control characters, and reserved filenames.
 pub fn sanitize_filename(name: &str) -> String {
     let sanitized: String = name
         .chars()
         .take(200)
         .map(|c| {
             if c.is_alphanumeric() || c == '-' || c == '_' || c > '\x7F' {
-                c
+                // Reject Unicode characters that resemble path separators
+                if c == '\u{FF0F}' || c == '\u{FF3C}' || c == '\u{2044}' || c == '\u{2215}' {
+                    '_'
+                } else {
+                    c
+                }
             } else {
                 '_'
             }
         })
         .collect();
     let sanitized = sanitized.trim_matches('.').to_string();
-    if sanitized.is_empty() || sanitized.contains("..") {
+    // Reject empty, path traversal sequences, and Windows reserved names
+    let upper = sanitized.to_uppercase();
+    let is_reserved = matches!(
+        upper.as_str(),
+        "CON" | "PRN" | "AUX" | "NUL" |
+        "COM1" | "COM2" | "COM3" | "COM4" | "COM5" | "COM6" | "COM7" | "COM8" | "COM9" |
+        "LPT1" | "LPT2" | "LPT3" | "LPT4" | "LPT5" | "LPT6" | "LPT7" | "LPT8" | "LPT9"
+    );
+    if sanitized.is_empty() || sanitized.contains("..") || is_reserved {
         format!("book_{}", now_secs())
     } else {
         sanitized
@@ -85,3 +99,4 @@ pub fn bytes_hash(data: &[u8]) -> String {
     hasher.update(data);
     format!("{:x}", hasher.finalize())
 }
+

--- a/core/src/search.rs
+++ b/core/src/search.rs
@@ -46,6 +46,9 @@ pub fn search_book(book: &EpubBook, query: &str, case_sensitive: bool) -> Vec<Se
                     .nth(20)
                     .map(|(i, _)| i)
                     .unwrap_or(0);
+                // Character-based match length for cross-platform consistency
+                let match_len_chars = query.chars().count();
+                let match_start_chars = text[..abs_pos].chars().count();
                 let ctx_end = text
                     .char_indices()
                     .filter(|&(i, _)| i >= abs_pos + query.len())
@@ -59,8 +62,8 @@ pub fn search_book(book: &EpubBook, query: &str, case_sensitive: bool) -> Vec<Se
                     chapter_title: chapter.title.clone(),
                     block_index: blk_idx,
                     context,
-                    match_start: abs_pos,
-                    match_len: query.len(),
+                    match_start: match_start_chars,
+                    match_len: match_len_chars,
                 });
                 start = abs_pos + query.len();
             }
@@ -71,7 +74,7 @@ pub fn search_book(book: &EpubBook, query: &str, case_sensitive: bool) -> Vec<Se
 
 fn block_text(block: &ContentBlock) -> String {
     match block {
-        ContentBlock::Paragraph { spans } | ContentBlock::Heading { spans, .. } => {
+        ContentBlock::Paragraph { spans, .. } | ContentBlock::Heading { spans, .. } => {
             spans.iter().map(|s| s.text.as_str()).collect()
         }
         _ => String::new(),


### PR DESCRIPTION
## 功能：段评核心支持

### 变更内容
- EpubBook 新增 chapter_reviews / review_chapter_indices 字段，自动识别以 " - 段评" 结尾的章节
- HTML 解析器增强：自动提取 Heading / Paragraph 的 anchor_id（原始 HTML 元素的 id 属性）
- ContentBlock 新增 anchor_id 字段
- 导出接口增加段评相关数据

### 合并顺序
**建议最先合并此 PR**（#15）。Desktop 和 Android 段评功能都依赖 core 中的数据结构变更。

### 后续依赖
- #16 feat(desktop): 段评面板
- #17 feat(android): 段评面板 + 默认左右翻页