### PR TITLE
feat(desktop): 段评面板

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -585,6 +585,9 @@ pub struct ReaderApp {
     pub clicked_highlight_id: Option<String>,
     pub hl_note_toolbar_pos: egui::Pos2,
     pub hl_note_just_opened: bool,
+    /// Cached bounding rect of the note popup from the previous frame,
+    /// used for reliable hit-testing (layer_id_at is unreliable in egui 0.29).
+    pub hl_note_popup_rect: Option<egui::Rect>,
     /// Note editing in annotations panel: highlight id being edited
     pub editing_note_id: Option<String>,
     pub editing_note_buf: String,
@@ -654,6 +657,15 @@ pub struct ReaderApp {
     pub csc_contribute_pr_url: Option<String>,
     pub csc_contribute_rx:
         Option<std::sync::mpsc::Receiver<crate::ui::csc_contribute::ContributeResult>>,
+    // ── Review Panel (段评覆盖层) ──
+    pub show_review_panel: bool,
+    pub review_panel_chapter: Option<usize>,
+    pub review_panel_anchor: Option<String>,
+    pub review_panel_just_opened: bool,
+    /// When true, show all blocks in the review panel; when false, filter to the anchored block only.
+    pub review_panel_show_all: bool,
+    /// Computed scroll offset for a clicked anchor link in the main reader.
+    pub anchor_scroll_offset: Option<f32>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -846,6 +858,7 @@ impl Default for ReaderApp {
             clicked_highlight_id: None,
             hl_note_toolbar_pos: egui::Pos2::ZERO,
             hl_note_just_opened: false,
+            hl_note_popup_rect: None,
             editing_note_id: None,
             editing_note_buf: String::new(),
             // TTS
@@ -901,6 +914,13 @@ impl Default for ReaderApp {
             csc_contribute_status: String::new(),
             csc_contribute_pr_url: None,
             csc_contribute_rx: None,
+            // Review Panel
+            show_review_panel: false,
+            review_panel_chapter: None,
+            review_panel_anchor: None,
+            review_panel_just_opened: false,
+            review_panel_show_all: true,
+            anchor_scroll_offset: None,
         };
 
         if let Some(settings) = AppSettings::load(&app.data_dir) {
@@ -1104,6 +1124,11 @@ impl ReaderApp {
                 self.current_chapter = ch;
                 self.last_synced_chapter = None; // Reset so progress is pushed immediately on first update
                 self.scroll_to_top = true;
+                // Reset review panel state when switching books
+                self.show_review_panel = false;
+                self.review_panel_chapter = None;
+                self.review_panel_anchor = None;
+                self.review_panel_just_opened = false;
                 self.pages_dirty = true;
                 self.current_page = 0;
                 self.view = AppView::Reader;
@@ -1144,7 +1169,22 @@ impl ReaderApp {
     pub fn next_chapter(&mut self) {
         let total = self.total_chapters();
         if total > 0 && self.current_chapter < total - 1 {
+            let original = self.current_chapter;
             self.current_chapter += 1;
+            // Skip review chapters (段评)
+            if let Some(book) = &self.book {
+                while self.current_chapter < total - 1
+                    && book.review_chapter_indices.contains(&self.current_chapter)
+                {
+                    self.current_chapter += 1;
+                }
+                // If we still landed on a review chapter at the last position,
+                // all remaining chapters are reviews — stay put.
+                if book.review_chapter_indices.contains(&self.current_chapter) {
+                    self.current_chapter = original;
+                    return;
+                }
+            }
             self.scroll_to_top = true;
             self.pages_dirty = true;
             self.current_page = 0;
@@ -1172,7 +1212,22 @@ impl ReaderApp {
 
     pub fn prev_chapter(&mut self) {
         if self.current_chapter > 0 {
+            let original = self.current_chapter;
             self.current_chapter -= 1;
+            // Skip review chapters (段评)
+            if let Some(book) = &self.book {
+                while self.current_chapter > 0
+                    && book.review_chapter_indices.contains(&self.current_chapter)
+                {
+                    self.current_chapter -= 1;
+                }
+                // If we still landed on a review chapter at position 0,
+                // all preceding chapters are reviews — stay put.
+                if book.review_chapter_indices.contains(&self.current_chapter) {
+                    self.current_chapter = original;
+                    return;
+                }
+            }
             self.scroll_to_top = true;
             self.pages_dirty = true;
             self.current_page = 0;
@@ -1278,7 +1333,7 @@ impl ReaderApp {
                     .enumerate()
                     .filter_map(|(i, block)| {
                         let spans = match block {
-                            ContentBlock::Paragraph { spans } => spans,
+                            ContentBlock::Paragraph { spans, .. } => spans,
                             ContentBlock::Heading { spans, .. } => spans,
                             _ => return None,
                         };
@@ -1973,7 +2028,7 @@ impl eframe::App for ReaderApp {
             ctx.request_repaint();
         }
 
-        if self.view == AppView::Reader && !self.show_sharing_panel {
+        if self.view == AppView::Reader && !self.show_sharing_panel && !self.show_review_panel {
             ctx.input(|i| {
                 if i.key_pressed(egui::Key::ArrowLeft) {
                     if self.scroll_mode {
@@ -2065,6 +2120,13 @@ impl eframe::App for ReaderApp {
             }
         }
 
+        // Dark mode: temporarily override reading background so the entire reader area is dark.
+        // This affects both CentralPanel fill and all internal rect fills in reader.rs.
+        let original_reader_bg = self.reader_bg_color;
+        if self.dark_mode && self.view == AppView::Reader {
+            self.reader_bg_color = egui::Color32::from_rgb(30, 30, 34);
+        }
+
         let reader_fill = if self.view == AppView::Reader {
             self.reader_bg_color
         } else if self.dark_mode {
@@ -2090,6 +2152,10 @@ impl eframe::App for ReaderApp {
         // ── Floating windows ──
         self.render_export_dialog(ctx);
         self.render_stats_window(ctx);
+        self.render_review_panel(ctx);
+
+        // Restore original reading background (do not persist dark-mode override)
+        self.reader_bg_color = original_reader_bg;
 
         // ── Sharing Panel ──
         if self.show_sharing_panel {

--- a/desktop/src/ui/annotations.rs
+++ b/desktop/src/ui/annotations.rs
@@ -114,7 +114,7 @@ impl ReaderApp {
                                         .map(|block| {
                                             let full: String = match block {
                                                 reader_core::epub::ContentBlock::Paragraph {
-                                                    spans,
+                                                    spans, ..
                                                 } => {
                                                     spans.iter().map(|s| s.text.as_str()).collect()
                                                 }

--- a/desktop/src/ui/csc_contribute.rs
+++ b/desktop/src/ui/csc_contribute.rs
@@ -99,7 +99,7 @@ impl ReaderApp {
 
             // Extract full block text
             let block_text: String = match block {
-                ContentBlock::Paragraph { spans } => {
+                ContentBlock::Paragraph { spans, .. } => {
                     spans.iter().map(|s| s.text.as_str()).collect()
                 }
                 ContentBlock::Heading { spans, .. } => {

--- a/desktop/src/ui/mod.rs
+++ b/desktop/src/ui/mod.rs
@@ -9,6 +9,7 @@ pub mod library;
 pub mod reader;
 pub mod reader_block;
 pub mod reader_state;
+pub mod review_panel;
 pub mod search;
 pub mod settings_new;
 pub mod sharing;

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -215,7 +215,9 @@ impl ReaderApp {
 
                 if self.scroll_mode {
                     let mut scroll_area = egui::ScrollArea::vertical().auto_shrink([false; 2]);
-                    if self.scroll_to_top {
+                    if let Some(y) = self.anchor_scroll_offset.take() {
+                        scroll_area = scroll_area.vertical_scroll_offset(y);
+                    } else if self.scroll_to_top {
                         scroll_area = scroll_area.vertical_scroll_offset(0.0);
                         self.scroll_to_top = false;
                     }
@@ -918,6 +920,7 @@ impl ReaderApp {
                         && self.clicked_highlight_id.is_none()
                         && self.csc_popup.is_none()
                         && !self.csc_custom_replace_active
+                        && !self.show_review_panel
                     {
                         let pointer_in_page = ui.input(|i| {
                             i.pointer
@@ -935,7 +938,8 @@ impl ReaderApp {
                         }
                         // Click-to-turn is handled in the selection release handler
                         // to avoid conflict with sel_press_origin
-                        if clicked_link.is_none()
+                        if !self.show_review_panel
+                            && clicked_link.is_none()
                             && self.sel_press_origin.is_none()
                             && ui.input(|i| i.pointer.primary_clicked())
                         {
@@ -1011,7 +1015,53 @@ impl ReaderApp {
                 || lowered.starts_with("tel:")
             {
                 ui.ctx().open_url(egui::OpenUrl::new_tab(url));
-            } else if !url.starts_with('#') {
+            } else if url.starts_with('#') {
+                let anchor = &url[1..];
+                if let Some(book) = &self.book {
+                    if let Some(chapter) = book.chapters.get(self.current_chapter) {
+                        if let Some(block_idx) = chapter.blocks.iter().position(|block| {
+                            match block {
+                                ContentBlock::Heading { anchor_id: Some(id), .. } => id == anchor,
+                                ContentBlock::Paragraph { anchor_id: Some(id), .. } => id == anchor,
+                                _ => false,
+                            }
+                        }) {
+                            if self.scroll_mode {
+                                let available_width = ui.available_width();
+                                let text_width = if available_width > DUAL_COLUMN_THRESHOLD {
+                                    let col_w = (available_width - DUAL_COLUMN_GAP) / 2.0;
+                                    (col_w - DUAL_COLUMN_PADDING).min(MAX_COLUMN_WIDTH)
+                                } else {
+                                    MAX_TEXT_WIDTH_SINGLE.min(available_width - SINGLE_TEXT_PADDING)
+                                };
+                                let line_height = self.font_size * line_spacing();
+                                let mut offset = 0.0;
+                                for (i, block) in chapter.blocks.iter().enumerate() {
+                                    if i >= block_idx {
+                                        break;
+                                    }
+                                    offset += estimate_block_height(
+                                        block,
+                                        self.font_size,
+                                        line_height,
+                                        text_width,
+                                    );
+                                }
+                                self.anchor_scroll_offset = Some(offset);
+                            } else {
+                                for (page_idx, (start, end)) in
+                                    self.page_block_ranges.iter().enumerate()
+                                {
+                                    if block_idx >= *start && block_idx < *end {
+                                        self.current_page = page_idx;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
                 let normalized = normalize_epub_href(&url);
                 let target_idx = if !normalized.is_empty() {
                     self.book.as_ref().and_then(|book| {
@@ -1029,10 +1079,23 @@ impl ReaderApp {
                     None
                 };
                 if let Some(idx) = target_idx {
-                    self.current_chapter = idx;
-                    self.current_page = 0;
-                    self.scroll_to_top = true;
-                    self.pages_dirty = true;
+                    // Check if target is a review chapter (段评) — show overlay instead of navigating
+                    if self.book.as_ref().map_or(false, |b| b.review_chapter_indices.contains(&idx)) {
+                        self.show_review_panel = true;
+                        self.review_panel_chapter = Some(idx);
+                        self.review_panel_anchor = url.split('#').nth(1).map(|s| s.to_string());
+                        self.review_panel_just_opened = true;
+                        // Clear any open highlight popup / selection so they don't fight for focus
+                        self.clicked_highlight_id = None;
+                        self.hl_note_popup_rect = None;
+                        self.text_selection = None;
+                        self.sel_press_origin = None;
+                    } else {
+                        self.current_chapter = idx;
+                        self.current_page = 0;
+                        self.scroll_to_top = true;
+                        self.pages_dirty = true;
+                    }
                 } else {
                     ui.ctx().open_url(egui::OpenUrl::new_tab(url));
                 }
@@ -1070,11 +1133,13 @@ impl ReaderApp {
         let block_galleys: Vec<BlockGalleyEntry> =
             BLOCK_GALLEYS.with(|bg| bg.borrow_mut().drain(..).collect());
 
-        // Detect primary pointer press / drag / release for selection
-        let pointer_pos = ui.ctx().input(|i| i.pointer.interact_pos());
         let primary_down = ui.ctx().input(|i| i.pointer.primary_down());
-        let primary_pressed = ui.ctx().input(|i| i.pointer.primary_pressed());
-        let primary_released = ui.ctx().input(|i| i.pointer.primary_released());
+        let pointer_pos = ui.ctx().input(|i| i.pointer.interact_pos().or_else(|| i.pointer.hover_pos()));
+
+        // Detect primary pointer press / drag / release for selection
+        if !self.show_review_panel {
+            let primary_pressed = ui.ctx().input(|i| i.pointer.primary_pressed());
+            let primary_released = ui.ctx().input(|i| i.pointer.primary_released());
 
         // Helper: find which block a screen position falls into and return (block_idx, char_offset)
         let hit_test = |pos: egui::Pos2| -> Option<(usize, usize)> {
@@ -1091,10 +1156,15 @@ impl ReaderApp {
         // Check if pointer is over a toolbar area (so we don't start selection there)
         let toolbar_id = egui::Id::new("sel_toolbar");
         let note_toolbar_id = egui::Id::new("hl_note_toolbar");
-        let over_toolbar = ui.ctx().memory(|mem| {
-            mem.layer_id_at(pointer_pos.unwrap_or_default())
-                .is_some_and(|layer| layer.id == toolbar_id || layer.id == note_toolbar_id)
-        });
+        // Use cached popup rect for reliable hit-testing (layer_id_at is unreliable in egui 0.29)
+        let over_popup_rect = self
+            .hl_note_popup_rect
+            .is_some_and(|rect| pointer_pos.is_some_and(|pos| rect.contains(pos)));
+        let over_toolbar = over_popup_rect
+            || ui.ctx().memory(|mem| {
+                mem.layer_id_at(pointer_pos.unwrap_or_default())
+                    .is_some_and(|layer| layer.id == toolbar_id || layer.id == note_toolbar_id)
+            });
 
         if let Some(pos) = pointer_pos {
             const DRAG_THRESHOLD: f32 = 5.0;
@@ -1103,18 +1173,18 @@ impl ReaderApp {
                 if let Some((block_idx, char_idx)) = hit_test(pos) {
                     // Record press origin; don't create TextSelection yet
                     self.sel_press_origin = Some((pos, block_idx, char_idx));
-                    // Clear any existing finalized selection or highlight popup
+                    // Clear any existing finalized selection
                     if self.text_selection.as_ref().is_some_and(|s| !s.is_dragging) {
                         self.text_selection = None;
                     }
-                    if self.clicked_highlight_id.is_some() {
-                        self.clicked_highlight_id = None;
-                    }
+                    // Don't clear clicked_highlight_id here — let the popup's
+                    // own close detection handle it on primary_clicked (release).
                 } else {
-                    // Clicked outside any block → clear everything
+                    // Clicked outside any block → clear selection state
                     self.sel_press_origin = None;
                     self.text_selection = None;
-                    self.clicked_highlight_id = None;
+                    // Don't clear clicked_highlight_id — popup close detection
+                    // will handle it on primary_clicked.
                 }
             } else if primary_down && !over_toolbar {
                 // If we have a pending press origin but no selection yet, check threshold
@@ -1130,6 +1200,11 @@ impl ReaderApp {
                             is_dragging: true,
                         });
                         self.sel_press_origin = None;
+                        // Close any open highlight popup when starting a drag
+                        if self.clicked_highlight_id.is_some() {
+                            self.clicked_highlight_id = None;
+                            self.hl_note_popup_rect = None;
+                        }
                     }
                 }
                 // Update end of an active selection while dragging
@@ -1263,6 +1338,7 @@ impl ReaderApp {
                     }
                 }
             }
+        }
         }
 
         // ── Draw selection highlight overlay (blue rectangles) ──
@@ -1556,7 +1632,7 @@ impl ReaderApp {
             let note_toolbar_id = egui::Id::new("hl_note_toolbar");
             let mut close_popup = false;
 
-            egui::Area::new(note_toolbar_id)
+            let area_resp = egui::Area::new(note_toolbar_id)
                 .fixed_pos(egui::pos2(popup_pos.x - 160.0, popup_pos.y - 170.0))
                 .order(egui::Order::Foreground)
                 .interactable(true)
@@ -1638,17 +1714,22 @@ impl ReaderApp {
                     });
                 });
 
+            // Use the Area's response rect (guaranteed screen coordinates) for hit-testing
+            let popup_rect = area_resp.response.rect;
+
+            // Cache the popup rect for next frame's over_toolbar check
+            self.hl_note_popup_rect = Some(popup_rect);
+
             // Close popup on click outside (skip the frame it was just opened)
             if !close_popup {
                 if self.hl_note_just_opened {
                     self.hl_note_just_opened = false;
-                } else {
+                } else if !self.show_review_panel {
                     let any_click = ui.ctx().input(|i| i.pointer.primary_clicked());
                     if any_click {
-                        let over_note_popup = ui.ctx().memory(|mem| {
-                            mem.layer_id_at(pointer_pos.unwrap_or_default())
-                                .is_some_and(|layer| layer.id == note_toolbar_id)
-                        });
+                        let over_note_popup = ui.ctx()
+                            .pointer_interact_pos()
+                            .is_some_and(|pos| popup_rect.contains(pos));
                         if !over_note_popup {
                             close_popup = true;
                         }
@@ -1659,14 +1740,18 @@ impl ReaderApp {
             if close_popup {
                 self.clicked_highlight_id = None;
                 self.editing_note_buf.clear();
+                self.hl_note_popup_rect = None;
             }
+        } else {
+            // Popup not shown — clear cached rect
+            self.hl_note_popup_rect = None;
         }
 
         // ── CSC correction click detection + popup ──
         {
             // Check if user clicked on a correction rect (ReadWrite mode)
             let any_click = ui.ctx().input(|i| i.pointer.primary_clicked());
-            if any_click && self.csc_popup.is_none() && self.text_selection.is_none() {
+            if any_click && !self.show_review_panel && self.csc_popup.is_none() && self.text_selection.is_none() {
                 if let Some(click_pos) = ui.ctx().pointer_interact_pos() {
                     CSC_RECTS.with(|rects| {
                         let r = rects.borrow();
@@ -1808,5 +1893,6 @@ impl ReaderApp {
                 }
             }
         }
+
     }
 }

--- a/desktop/src/ui/reader_block.rs
+++ b/desktop/src/ui/reader_block.rs
@@ -167,7 +167,7 @@ pub(crate) fn render_block(
     highlight_ranges: &[(usize, usize, reader_core::library::HighlightColor)],
 ) {
     match block {
-        ContentBlock::Heading { level, spans } => {
+        ContentBlock::Heading { level, spans, .. } => {
             let scale = match level {
                 1 => 2.0,
                 2 => 1.6,
@@ -189,7 +189,7 @@ pub(crate) fn render_block(
             let galley = ui.painter().layout_job(job);
             let galley_size = galley.size();
             let (rect, response) =
-                ui.allocate_exact_size(galley_size, egui::Sense::click_and_drag());
+                ui.allocate_exact_size(galley_size, egui::Sense::click());
 
             if is_tts_block {
                 paint_tts_highlight(ui, rect);
@@ -224,7 +224,7 @@ pub(crate) fn render_block(
             }
             ui.add_space(font_size * 0.4);
         }
-        ContentBlock::Paragraph { spans } => {
+        ContentBlock::Paragraph { spans, .. } => {
             let is_readwrite = CSC_READWRITE.get();
 
             // ── Build display spans and annotation info based on CSC state ──
@@ -343,7 +343,7 @@ pub(crate) fn render_block(
             let galley = ui.painter().layout_job(job);
             let galley_size = galley.size();
             let (rect, response) =
-                ui.allocate_exact_size(galley_size, egui::Sense::click_and_drag());
+                ui.allocate_exact_size(galley_size, egui::Sense::click());
             // TTS read-along highlight (paint behind text)
             if TTS_HIGHLIGHT_BLOCK.get() == Some(chapter_block_idx) {
                 paint_tts_highlight(ui, rect);
@@ -780,7 +780,7 @@ pub(crate) fn estimate_block_height(
     max_width: f32,
 ) -> f32 {
     match block {
-        ContentBlock::Heading { level, spans } => {
+        ContentBlock::Heading { level, spans, .. } => {
             let scale = match level {
                 1 => 2.0,
                 2 => 1.6,
@@ -791,7 +791,7 @@ pub(crate) fn estimate_block_height(
             let text_len: f32 = spans.iter().map(|s| estimate_text_width(&s.text, sz)).sum();
             (text_len / max_width).ceil().max(1.0) * sz * line_spacing() + font_size * 1.2
         }
-        ContentBlock::Paragraph { spans } => {
+        ContentBlock::Paragraph { spans, .. } => {
             let text_len: f32 = spans
                 .iter()
                 .map(|s| estimate_text_width(&s.text, font_size))

--- a/desktop/src/ui/review_panel.rs
+++ b/desktop/src/ui/review_panel.rs
@@ -1,0 +1,501 @@
+//! Review panel (段评覆盖层) — slides out from the right with a semi-transparent backdrop.
+use std::cell::Cell;
+
+use crate::app::ReaderApp;
+use eframe::egui;
+
+/// Parsed review card from a paragraph text like:
+/// "1. 【内容】 作者：xxx | 时间：xxx | 赞：52"
+struct ReviewCard {
+    #[allow(dead_code)]
+    index: usize,
+    content: String,
+    author: String,
+    timestamp: String,
+    likes: usize,
+}
+
+/// Try to parse a review paragraph into structured card data.
+fn parse_review_card(text: &str) -> Option<ReviewCard> {
+    let trimmed = text.trim();
+
+    // Extract index: "1. ..."
+    let dot_pos = trimmed.find('.')?;
+    let index = trimmed[..dot_pos].trim().parse::<usize>().ok()?;
+    let rest = trimmed[dot_pos + 1..].trim();
+
+    // Split by " | " or " ｜ "
+    let parts: Vec<&str> = rest.split(|c: char| c == '|' || c == '｜').collect();
+    if parts.len() < 3 {
+        return None;
+    }
+
+    // Last part: "赞：52"
+    let likes_part = parts.last()?.trim();
+    let likes_str = likes_part
+        .strip_prefix("赞：")
+        .or_else(|| likes_part.strip_prefix("赞:"))?
+        .trim();
+    let likes = likes_str.parse::<usize>().ok()?;
+
+    // Second-to-last part: "时间：1770036499"
+    let time_part = parts[parts.len() - 2].trim();
+    let timestamp = time_part
+        .strip_prefix("时间：")
+        .or_else(|| time_part.strip_prefix("时间:"))?
+        .trim()
+        .to_string();
+
+    // First part: "【内容】 作者：吃草莓布丁吗"
+    let first_part = parts[0].trim();
+    let author_marker = "作者：";
+    let author_pos = first_part
+        .rfind(author_marker)
+        .or_else(|| first_part.rfind("作者:"))?;
+    let content = first_part[..author_pos].trim().to_string();
+    let author = first_part[author_pos + author_marker.len()..].trim().to_string();
+
+    Some(ReviewCard {
+        index,
+        content,
+        author,
+        timestamp,
+        likes,
+    })
+}
+
+/// Convert a Unix timestamp string (or any string) to human-readable format.
+fn format_timestamp(s: &str) -> String {
+    if let Ok(ts) = s.parse::<u64>() {
+        format_unix_timestamp(ts)
+    } else {
+        s.to_string()
+    }
+}
+
+fn format_unix_timestamp(ts: u64) -> String {
+    const SECONDS_PER_DAY: u64 = 86400;
+    let mut days = ts / SECONDS_PER_DAY;
+    let rem = ts % SECONDS_PER_DAY;
+    let mut year: u64 = 1970;
+    loop {
+        let dim = if is_leap_year(year) { 366 } else { 365 };
+        if days < dim {
+            break;
+        }
+        days -= dim;
+        year += 1;
+    }
+    let month_days = [
+        31,
+        if is_leap_year(year) { 29 } else { 28 },
+        31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+    ];
+    let mut month = 1;
+    let mut day = days as u32;
+    for dim in month_days.iter() {
+        if day < *dim {
+            break;
+        }
+        day -= *dim;
+        month += 1;
+    }
+    let hour = rem / 3600;
+    let minute = (rem % 3600) / 60;
+    format!("{:04}-{:02}-{:02} {:02}:{:02}", year, month, day + 1, hour, minute)
+}
+
+fn is_leap_year(y: u64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0)
+}
+
+/// Estimate how many lines of text fit in the given width.
+fn estimate_text_lines(text: &str, font_size: f32, content_width: f32) -> f32 {
+    if text.is_empty() || content_width <= 0.0 {
+        return 0.0;
+    }
+    // Conservative estimate for CJK / mixed text in egui's default font.
+    let avg_char_width = font_size * 0.55;
+    let chars_per_line = (content_width / avg_char_width).max(1.0);
+    let text_len = text.chars().count() as f32;
+    (text_len / chars_per_line).ceil().max(1.0)
+}
+
+/// Estimate the on-screen height of a content block inside the review panel.
+fn estimate_block_height(
+    block: &reader_core::epub::ContentBlock,
+    font_size: f32,
+    content_width: f32,
+) -> f32 {
+    match block {
+        reader_core::epub::ContentBlock::Heading {
+            level, spans, ..
+        } => {
+            let text: String = spans.iter().map(|s| s.text.as_str()).collect();
+            let size = match level {
+                1 => 18.0,
+                2 => 16.0,
+                _ => 14.0,
+            };
+            let lines = estimate_text_lines(&text, size, content_width);
+            lines * size + 6.0 // trailing space
+        }
+        reader_core::epub::ContentBlock::Paragraph { spans, .. } => {
+            let text: String = spans.iter().map(|s| s.text.as_str()).collect();
+            if text.trim().is_empty() {
+                return 0.0;
+            }
+            let lines = estimate_text_lines(&text, font_size, content_width);
+            lines * font_size * 1.6 + 4.0
+        }
+        reader_core::epub::ContentBlock::Separator => 12.0,
+        reader_core::epub::ContentBlock::BlankLine => font_size * 0.5,
+        _ => 0.0,
+    }
+}
+
+/// Compute scroll offset so the block matching `anchor_id` appears near the top.
+fn compute_anchor_scroll_offset(
+    blocks: &[reader_core::epub::ContentBlock],
+    anchor_id: &str,
+    font_size: f32,
+    content_width: f32,
+) -> Option<f32> {
+    // The header (title bar, separator, chapter title) is rendered *outside* the
+    // ScrollArea, so vertical_scroll_offset is relative to the ScrollArea content only.
+    let mut offset = 0.0;
+    for block in blocks {
+        let is_match = match block {
+            reader_core::epub::ContentBlock::Heading {
+                anchor_id: Some(id),
+                ..
+            } => id == anchor_id,
+            reader_core::epub::ContentBlock::Paragraph {
+                anchor_id: Some(id),
+                ..
+            } => id == anchor_id,
+            _ => false,
+        };
+        if is_match {
+            return Some(offset);
+        }
+        offset += estimate_block_height(block, font_size, content_width);
+    }
+    None
+}
+
+impl ReaderApp {
+    pub fn render_review_panel(&mut self, ctx: &egui::Context) {
+        if !self.show_review_panel {
+            return;
+        }
+        // ESC / Android back key closes the panel
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            self.show_review_panel = false;
+            self.review_panel_chapter = None;
+            self.review_panel_anchor = None;
+            return;
+        }
+        // Consume just_opened immediately so it never survives an early return.
+        let was_just_opened = self.review_panel_just_opened;
+        self.review_panel_just_opened = false;
+
+        // When opening from an anchor link, default to filtered view (only that paragraph)
+        if was_just_opened && self.review_panel_anchor.is_some() {
+            self.review_panel_show_all = false;
+        }
+
+        let Some(review_ch_idx) = self.review_panel_chapter else {
+            return;
+        };
+        let chapter = self
+            .book
+            .as_ref()
+            .and_then(|b| b.chapters.get(review_ch_idx));
+        let Some(chapter) = chapter else {
+            return;
+        };
+
+        let screen_rect = ctx.screen_rect();
+        let panel_width = (screen_rect.width() * 0.42).max(360.0).min(500.0);
+        let close = Cell::new(false);
+
+        // ── Compute anchor scroll offset (only on the frame the panel opens) ──
+        let content_width = panel_width - 32.0; // margin * 2
+        let scroll_offset = if was_just_opened {
+            self.review_panel_anchor.as_ref().and_then(|anchor| {
+                compute_anchor_scroll_offset(&chapter.blocks, anchor, self.font_size, content_width)
+            })
+        } else {
+            None
+        };
+
+        // ── Backdrop (semi-transparent black overlay, visual only) ──
+        // Backdrop does NOT register click interaction — close only via ✕ button.
+        // This avoids egui focus/state issues that caused permanent input lock.
+        egui::Area::new(egui::Id::new("review_backdrop"))
+            .fixed_pos(screen_rect.min)
+            .order(egui::Order::Foreground)
+            .interactable(false)
+            .show(ctx, |ui| {
+                ui.set_min_size(screen_rect.size());
+                let rect = ui.max_rect();
+                ui.painter()
+                    .rect_filled(rect, 0.0, egui::Color32::from_black_alpha(140));
+            });
+
+        // ── Right-side sliding panel ──
+        let panel_pos = egui::pos2(screen_rect.right() - panel_width, screen_rect.top());
+        let panel_rect =
+            egui::Rect::from_min_size(panel_pos, egui::vec2(panel_width, screen_rect.height()));
+
+        egui::Area::new(egui::Id::new("review_panel"))
+            .fixed_pos(panel_pos)
+            .order(egui::Order::Foreground)
+            .interactable(true)
+            .show(ctx, |ui| {
+                let bg = ctx.style().visuals.panel_fill;
+                ui.painter().rect_filled(panel_rect, 0.0, bg);
+                // Interact over the whole panel so clicks on margins/title don't fall through to the backdrop
+                ui.interact(panel_rect, ui.id(), egui::Sense::click());
+
+                // Shadow on left edge of panel
+                let shadow_steps = 12u32;
+                let shadow_w = 20.0f32;
+                for i in 0..shadow_steps {
+                    let alpha = ((shadow_steps - i) as f32 * 35.0 / shadow_steps as f32) as u8;
+                    let x = panel_rect.left() + i as f32 * (shadow_w / shadow_steps as f32);
+                    ui.painter().rect_filled(
+                        egui::Rect::from_min_size(
+                            egui::pos2(x, panel_rect.top()),
+                            egui::vec2(shadow_w / shadow_steps as f32, panel_rect.height()),
+                        ),
+                        0.0,
+                        egui::Color32::from_black_alpha(alpha),
+                    );
+                }
+
+                let margin = 16.0;
+                let content_rect = panel_rect.shrink2(egui::vec2(margin, margin));
+                ui.set_clip_rect(panel_rect);
+
+                ui.allocate_new_ui(
+                    egui::UiBuilder::new().max_rect(content_rect),
+                    |ui| {
+                        // Header
+                        ui.horizontal(|ui| {
+                            ui.heading(self.i18n.t("review.panel_title"));
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    if ui.button("✕").clicked() {
+                                        close.set(true);
+                                    }
+                                },
+                            );
+                        });
+
+                        // Filter toggle (only when opened from an anchor)
+                        if self.review_panel_anchor.is_some() {
+                            ui.horizontal(|ui| {
+                                let label = if self.review_panel_show_all {
+                                    "🔍 只看当前段"
+                                } else {
+                                    "📖 显示全部"
+                                };
+                                if ui.button(label).clicked() {
+                                    self.review_panel_show_all = !self.review_panel_show_all;
+                                }
+                            });
+                        }
+                        ui.separator();
+
+                        // Chapter title
+                        ui.label(
+                            egui::RichText::new(&chapter.title)
+                                .size(14.0)
+                                .color(egui::Color32::GRAY),
+                        );
+                        ui.add_space(8.0);
+
+                        // Scrollable content
+                        let mut scroll_area = egui::ScrollArea::vertical();
+                        if let Some(y) = scroll_offset {
+                            scroll_area = scroll_area.vertical_scroll_offset(y);
+                        }
+                        let anchor_filter = self.review_panel_anchor.clone();
+                        let show_all = self.review_panel_show_all;
+
+                        // Build filtered block list: when filtering, find the Heading that
+                        // matches the anchor and include it plus all following non-Heading
+                        // blocks until the next Heading (paragraph group).
+
+                        let filtered_blocks: Vec<&reader_core::epub::ContentBlock> =
+                            if let Some(ref filter) = anchor_filter {
+                                if !show_all {
+                                    let mut result = Vec::new();
+                                    let mut in_group = false;
+                                    for block in &chapter.blocks {
+                                        match block {
+                                            reader_core::epub::ContentBlock::Heading {
+                                                anchor_id,
+                                                ..
+                                            } => {
+                                                if anchor_id.as_ref() == Some(filter) {
+                                                    in_group = true;
+                                                    result.push(block);
+                                                } else if in_group {
+                                                    // Reached next heading — stop
+                                                    break;
+                                                }
+                                                // Before match: skip headings
+                                            }
+                                            _ => {
+                                                if in_group {
+                                                    result.push(block);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    result
+                                } else {
+                                    chapter.blocks.iter().collect()
+                                }
+                            } else {
+                                chapter.blocks.iter().collect()
+                            };
+
+                        scroll_area.show(ui, |ui| {
+                            for block in &filtered_blocks {
+                                match block {
+                                    reader_core::epub::ContentBlock::Heading {
+                                        level,
+                                        spans,
+                                        ..
+                                    } => {
+                                        let text: String =
+                                            spans.iter().map(|s| s.text.as_str()).collect();
+                                        let size = match level {
+                                            1 => 18.0,
+                                            2 => 16.0,
+                                            _ => 14.0,
+                                        };
+                                        ui.label(
+                                            egui::RichText::new(&text).size(size).strong(),
+                                        );
+                                        ui.add_space(6.0);
+                                    }
+                                    reader_core::epub::ContentBlock::Paragraph { spans, .. } => {
+                                        let text: String =
+                                            spans.iter().map(|s| s.text.as_str()).collect();
+                                        let trimmed = text.trim();
+                                        if trimmed.is_empty() {
+                                            continue;
+                                        }
+
+                                        // Try to render as review card
+                                        if let Some(card) = parse_review_card(&text) {
+                                            let card_bg = ui.visuals().extreme_bg_color;
+                                            let frame = egui::Frame::new()
+                                                .fill(card_bg)
+                                                .corner_radius(6.0)
+                                                .inner_margin(10.0)
+                                                .stroke(ui.visuals().widgets.noninteractive.bg_stroke);
+                                            frame.show(ui, |ui| {
+                                                ui.set_width(ui.available_width());
+                                                // Author
+                                                ui.horizontal(|ui| {
+                                                    ui.label(
+                                                        egui::RichText::new(&card.author)
+                                                            .size(13.0)
+                                                            .color(egui::Color32::from_rgb(64, 128, 200))
+                                                            .strong(),
+                                                    );
+                                                });
+                                                ui.add_space(4.0);
+                                                // Content
+                                                ui.label(
+                                                    egui::RichText::new(&card.content)
+                                                        .size(14.0),
+                                                );
+                                                ui.add_space(6.0);
+                                                // Meta row: time + likes
+                                                ui.horizontal(|ui| {
+                                                    let time_str = format_timestamp(&card.timestamp);
+                                                    ui.label(
+                                                        egui::RichText::new(&time_str)
+                                                            .size(11.0)
+                                                            .color(egui::Color32::GRAY),
+                                                    );
+                                                    ui.with_layout(
+                                                        egui::Layout::right_to_left(egui::Align::Center),
+                                                        |ui| {
+                                                            ui.label(
+                                                                egui::RichText::new(format!("❤ {}", card.likes))
+                                                                    .size(11.0)
+                                                                    .color(egui::Color32::GRAY),
+                                                            );
+                                                        },
+                                                    );
+                                                });
+                                            });
+                                            ui.add_space(8.0);
+                                        } else {
+                                            // Fallback: render as normal paragraph with link support
+                                            ui.horizontal_wrapped(|ui| {
+                                                for span in spans {
+                                                    let mut label = egui::RichText::new(&span.text)
+                                                        .size(self.font_size);
+                                                    if span.link_url.is_some() {
+                                                        label = label
+                                                            .color(egui::Color32::from_rgb(
+                                                                30, 80, 200,
+                                                            ))
+                                                            .underline();
+                                                    }
+                                                    let resp = ui.add(egui::Label::new(label).sense(
+                                                        if span.link_url.is_some() {
+                                                            egui::Sense::click()
+                                                        } else {
+                                                            egui::Sense::hover()
+                                                        },
+                                                    ));
+                                                    if resp.clicked() {
+                                                        if let Some(url) = &span.link_url {
+                                                            let url = url.trim();
+                                                            if url.starts_with('#') || url.is_empty() {
+                                                                close.set(true);
+                                                            } else {
+                                                                ctx.open_url(
+                                                                    egui::OpenUrl::new_tab(url),
+                                                                );
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            });
+                                            ui.add_space(4.0);
+                                        }
+                                    }
+                                    reader_core::epub::ContentBlock::Separator => {
+                                        ui.separator();
+                                        ui.add_space(4.0);
+                                    }
+                                    reader_core::epub::ContentBlock::BlankLine => {
+                                        ui.add_space(self.font_size * 0.5);
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        });
+                    },
+                );
+            });
+
+        if close.get() {
+            self.show_review_panel = false;
+            self.review_panel_chapter = None;
+            self.review_panel_anchor = None;
+        }
+    }
+}

--- a/desktop/src/ui/toolbar.rs
+++ b/desktop/src/ui/toolbar.rs
@@ -29,6 +29,11 @@ impl ReaderApp {
             {
                 self.flush_reading_stats();
                 self.view = AppView::Library;
+                // Reset review panel state when returning to library
+                self.show_review_panel = false;
+                self.review_panel_chapter = None;
+                self.review_panel_anchor = None;
+                self.review_panel_just_opened = false;
             }
             ui.add_space(2.0);
             if ui

--- a/desktop/src/ui/tts.rs
+++ b/desktop/src/ui/tts.rs
@@ -308,7 +308,7 @@ impl ReaderApp {
             .and_then(|b| {
                 b.chapters.get(self.current_chapter).and_then(|ch| {
                     ch.blocks.get(block_idx).map(|block| match block {
-                        reader_core::epub::ContentBlock::Paragraph { spans } => {
+                        reader_core::epub::ContentBlock::Paragraph { spans, .. } => {
                             spans.iter().map(|s| s.text.as_str()).collect::<String>()
                         }
                         reader_core::epub::ContentBlock::Heading { spans, .. } => {


### PR DESCRIPTION
## 功能：桌面端段评面板

### 变更内容
- 新增 desktop/src/ui/review_panel.rs：右侧滑出覆盖层
  - 卡片化渲染、锚点自动滚动、ESC 关闭、Dark 模式适配
- reader.rs：拦截段评链接，提取 #anchor 打开对应段落
- toolbar.rs：返回书库时自动关闭段评面板
- 适配 ContentBlock 新增的 anchor_id 字段

### 合并顺序
**建议在第 1 个 PR（#15 core）之后合并**。此 PR 依赖 core 中的段评数据结构。

### 前置依赖
- #15 feat(core): 段评核心支持