### PR TITLE
feat(android): 段评面板 + 默认左右翻页

### DIFF
--- a/android-bridge/src/lib.rs
+++ b/android-bridge/src/lib.rs
@@ -146,6 +146,13 @@ pub extern "C" fn Java_com_zhongbai233_epub_reader_RustBridge_openBook(
         Err(_) => return std::ptr::null_mut(),
     };
 
+    let chapter_reviews: Vec<serde_json::Value> = book
+        .chapter_reviews
+        .iter()
+        .map(|(k, v)| serde_json::json!({"main": k, "review": v}))
+        .collect();
+    let review_chapter_indices: Vec<usize> = book.review_chapter_indices.iter().copied().collect();
+
     let json = serde_json::json!({
         "title": book.title,
         "chapterCount": book.chapters.len(),
@@ -154,6 +161,8 @@ pub extern "C" fn Java_com_zhongbai233_epub_reader_RustBridge_openBook(
             "chapterIndex": t.chapter_index,
         })).collect::<Vec<_>>(),
         "hasCover": book.cover_data.is_some(),
+        "chapterReviews": chapter_reviews,
+        "reviewChapterIndices": review_chapter_indices,
     });
 
     jni_string_or_null!(env, json.to_string())
@@ -187,25 +196,27 @@ pub extern "C" fn Java_com_zhongbai233_epub_reader_RustBridge_getChapter(
         .blocks
         .iter()
         .map(|block| match block {
-            reader_core::epub::ContentBlock::Paragraph { spans } => {
+            reader_core::epub::ContentBlock::Paragraph { spans, anchor_id } => {
                 serde_json::json!({
                     "type": "paragraph",
                     "spans": spans.iter().map(|s| serde_json::json!({
                         "text": s.text,
-                        "style": format!("{:?}", s.style),
+                        "style": s.style.as_str(),
                         "linkUrl": s.link_url,
                     })).collect::<Vec<_>>(),
+                    "anchorId": anchor_id,
                 })
             }
-            reader_core::epub::ContentBlock::Heading { level, spans } => {
+            reader_core::epub::ContentBlock::Heading { level, spans, anchor_id } => {
                 serde_json::json!({
                     "type": "heading",
                     "level": level,
                     "spans": spans.iter().map(|s| serde_json::json!({
                         "text": s.text,
-                        "style": format!("{:?}", s.style),
+                        "style": s.style.as_str(),
                         "linkUrl": s.link_url,
                     })).collect::<Vec<_>>(),
+                    "anchorId": anchor_id,
                 })
             }
             reader_core::epub::ContentBlock::Separator => {
@@ -1713,7 +1724,7 @@ pub extern "C" fn Java_com_zhongbai233_epub_reader_RustBridge_collectCscSamples(
             None => continue,
         };
         let block_text: String = match block {
-            ContentBlock::Paragraph { spans } => spans.iter().map(|s| s.text.as_str()).collect(),
+            ContentBlock::Paragraph { spans, .. } => spans.iter().map(|s| s.text.as_str()).collect(),
             ContentBlock::Heading { spans, .. } => spans.iter().map(|s| s.text.as_str()).collect(),
             _ => continue,
         };

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -113,7 +113,8 @@ tasks.register<Exec>("cargoBuild") {
     workingDir = file("../../android-bridge")
     commandLine(
         "cargo", "ndk",
-        "-t", "arm64-v8a", 
+        "-t", "arm64-v8a",
+        "-t", "armeabi-v7a",
         "-t", "x86_64",
         "-o", "../android/app/src/main/jniLibs",
         "build", "--release"

--- a/android/app/src/main/java/com/epub/reader/MainActivity.kt
+++ b/android/app/src/main/java/com/epub/reader/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
@@ -23,6 +24,7 @@ import com.zhongbai233.epub.reader.ui.library.LibraryScreen
 import com.zhongbai233.epub.reader.ui.library.SharingDialog
 import com.zhongbai233.epub.reader.ui.library.TxtImportDialog
 import com.zhongbai233.epub.reader.ui.reader.ReaderScreen
+import com.zhongbai233.epub.reader.ui.reader.ReviewPanel
 import com.zhongbai233.epub.reader.ui.reader.SearchDialog
 import com.zhongbai233.epub.reader.ui.reader.ContributeDialog
 import com.zhongbai233.epub.reader.ui.reader.AnnotationsSheet
@@ -329,8 +331,33 @@ private fun MainContent(vm: ReaderViewModel) {
                         cscModelReady = vm.cscModelReady,
                         cscModelLoading = vm.cscModelLoading,
                         cscCorrections = vm.cscCorrections,
-                        onDownloadCscModel = { vm.downloadCscModel() }
+                        onDownloadCscModel = { vm.downloadCscModel() },
+                        // 段评
+                        reviewChapterIndices = vm.reviewChapterIndices,
+                        showReviewPanel = vm.showReviewPanel,
+                        reviewPanelChapter = vm.reviewPanelChapter,
+                        onOpenReviewPanel = { idx, anchor -> vm.openReviewPanel(idx, anchor) },
+                        onCloseReviewPanel = { vm.closeReviewPanel() }
                     )
+
+                    // 段评面板返回键拦截
+                    BackHandler(enabled = vm.showReviewPanel) {
+                        vm.closeReviewPanel()
+                    }
+
+                    // 段评面板
+                    if (vm.showReviewPanel && vm.reviewPanelChapter != null) {
+                        val reviewCh = book.chapters.getOrNull(vm.reviewPanelChapter!!)
+                        if (reviewCh != null) {
+                            ReviewPanel(
+                                chapterTitle = reviewCh.title,
+                                blocks = reviewCh.blocks,
+                                anchorId = vm.reviewPanelAnchor,
+                                fontSize = vm.fontSize,
+                                onDismiss = { vm.closeReviewPanel() }
+                            )
+                        }
+                    }
 
                     // 标注面板
                     if (vm.showAnnotationsPanel) {

--- a/android/app/src/main/java/com/epub/reader/model/Models.kt
+++ b/android/app/src/main/java/com/epub/reader/model/Models.kt
@@ -11,12 +11,30 @@ enum class InlineStyle {
     Normal, Bold, Italic, BoldItalic
 }
 
+/** 纠错状态 — 对应 Rust 版本的 CorrectionStatus */
+@Serializable
+enum class CorrectionStatus {
+    Pending, Accepted, Rejected, Ignored
+}
+
+/** 纠错信息 — 对应 Rust 版本的 CorrectionInfo */
+@Serializable
+data class CorrectionInfo(
+    val original: String,
+    val corrected: String,
+    val confidence: Float = 0f,
+    @SerialName("char_offset")
+    val charOffset: Int = 0,
+    val status: CorrectionStatus = CorrectionStatus.Pending
+)
+
 /** 文本片段 — 对应 Rust 版本的 TextSpan */
 @Serializable
 data class TextSpan(
     val text: String,
     val style: InlineStyle = InlineStyle.Normal,
-    val linkUrl: String? = null
+    val linkUrl: String? = null,
+    val correction: CorrectionInfo? = null
 )
 
 /** 内容块 — 对应 Rust 版本的 ContentBlock */
@@ -24,11 +42,11 @@ data class TextSpan(
 sealed class ContentBlock {
     @Serializable
     @SerialName("heading")
-    data class Heading(val level: Int, val spans: List<TextSpan>) : ContentBlock()
+    data class Heading(val level: Int, val spans: List<TextSpan>, val anchorId: String? = null) : ContentBlock()
 
     @Serializable
     @SerialName("paragraph")
-    data class Paragraph(val spans: List<TextSpan>) : ContentBlock()
+    data class Paragraph(val spans: List<TextSpan>, val anchorId: String? = null) : ContentBlock()
 
     @Serializable
     @SerialName("image")
@@ -59,11 +77,19 @@ data class TocEntryDto(
 )
 
 @Serializable
+data class ChapterReviewEntry(
+    val main: Int,
+    val review: Int
+)
+
+@Serializable
 data class BookMetadataDto(
     val title: String,
     val chapterCount: Int,
     val toc: List<TocEntryDto>,
-    val hasCover: Boolean
+    val hasCover: Boolean,
+    val chapterReviews: List<ChapterReviewEntry> = emptyList(),
+    val reviewChapterIndices: List<Int> = emptyList()
 )
 
 /** 方便与老代码兼容保留的 Chapter 定义（如果需要映射） */

--- a/android/app/src/main/java/com/epub/reader/ui/reader/ContentBlockView.kt
+++ b/android/app/src/main/java/com/epub/reader/ui/reader/ContentBlockView.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -136,10 +137,9 @@ internal fun ContentBlockView(
                             val isSmallMove = (up.position - down.position).getDistance() <= viewConfiguration.touchSlop
                             if (isQuickTap && isSmallMove) {
                                 layoutResult?.let { result ->
-                                    val offset = result.getOffsetForPosition(up.position)
-                                    val annotations = annotated.getStringAnnotations(tag = "URL", start = offset, end = offset)
-                                    if (annotations.isNotEmpty()) {
-                                        onLinkClick(annotations.first().item)
+                                    val url = result.findUrlAtPosition(up.position, annotated, extraPaddingPx = 30f)
+                                    if (url != null) {
+                                        onLinkClick(url)
                                     } else {
                                         onTextTapped()
                                     }
@@ -230,10 +230,9 @@ internal fun ContentBlockView(
                             val isSmallMove = (up.position - down.position).getDistance() <= viewConfiguration.touchSlop
                             if (isQuickTap && isSmallMove) {
                                 layoutResult?.let { result ->
-                                    val offset = result.getOffsetForPosition(up.position)
-                                    val annotations = annotated.getStringAnnotations(tag = "URL", start = offset, end = offset)
-                                    if (annotations.isNotEmpty()) {
-                                        onLinkClick(annotations.first().item)
+                                    val url = result.findUrlAtPosition(up.position, annotated, extraPaddingPx = 30f)
+                                    if (url != null) {
+                                        onLinkClick(url)
                                     } else {
                                         onTextTapped()
                                     }
@@ -295,4 +294,34 @@ private fun highlightColor(name: String): Color = when (name) {
     "Blue"   -> Color(0x5990CAF9)
     "Pink"   -> Color(0x59F48FB1)
     else     -> Color(0x59FFF176)
+}
+
+/**
+ * 在 TextLayoutResult 中查找点击位置是否落在某个 URL 链接的扩展边界框内。
+ * 先尝试精确字符匹配，失败后再检查链接边界框 ±[extraPaddingPx] 的扩展区域。
+ */
+private fun TextLayoutResult.findUrlAtPosition(
+    position: androidx.compose.ui.geometry.Offset,
+    annotated: AnnotatedString,
+    extraPaddingPx: Float = 30f
+): String? {
+    // 先精确匹配
+    val exactOffset = getOffsetForPosition(position)
+    annotated.getStringAnnotations(tag = "URL", start = exactOffset, end = exactOffset)
+        .firstOrNull()?.let { return it.item }
+
+    // 再检查扩展边界框
+    val all = annotated.getStringAnnotations(tag = "URL", start = 0, end = annotated.length)
+    for (ann in all) {
+        val startBox = getBoundingBox(ann.start)
+        val endBox = getBoundingBox((ann.end - 1).coerceAtLeast(ann.start))
+        val left = minOf(startBox.left, endBox.left) - extraPaddingPx
+        val top = minOf(startBox.top, endBox.top) - extraPaddingPx
+        val right = maxOf(startBox.right, endBox.right) + extraPaddingPx
+        val bottom = maxOf(startBox.bottom, endBox.bottom) + extraPaddingPx
+        if (position.x in left..right && position.y in top..bottom) {
+            return ann.item
+        }
+    }
+    return null
 }

--- a/android/app/src/main/java/com/epub/reader/ui/reader/ReaderScreen.kt
+++ b/android/app/src/main/java/com/epub/reader/ui/reader/ReaderScreen.kt
@@ -198,7 +198,13 @@ fun ReaderScreen(
     cscModelReady: Boolean = false,
     cscModelLoading: Boolean = false,
     cscCorrections: List<com.zhongbai233.epub.reader.csc.CorrectionInfo> = emptyList(),
-    onDownloadCscModel: () -> Unit = {}
+    onDownloadCscModel: () -> Unit = {},
+    // 段评
+    reviewChapterIndices: Set<Int> = emptySet(),
+    showReviewPanel: Boolean = false,
+    reviewPanelChapter: Int? = null,
+    onOpenReviewPanel: (Int, String?) -> Unit = { _, _ -> },
+    onCloseReviewPanel: () -> Unit = {}
 ) {
     var textSelection by remember { mutableStateOf<TextSelectionState?>(null) }
     var selectionAnchorRange by remember { mutableStateOf<TextSelectionState?>(null) }
@@ -242,7 +248,13 @@ fun ReaderScreen(
                         }
 
                         if (target >= 0) {
-                            onChapterChange(target)
+                            // Intercept review chapters (段评) — show overlay instead of navigating
+                            if (reviewChapterIndices.contains(target)) {
+                                val anchor = link.substringAfter('#', "")
+                                onOpenReviewPanel(target, anchor.takeIf { it.isNotBlank() })
+                            } else {
+                                onChapterChange(target)
+                            }
                         } else {
                             runCatching { uriHandler.openUri(link) }
                         }

--- a/android/app/src/main/java/com/epub/reader/ui/reader/ReviewPanel.kt
+++ b/android/app/src/main/java/com/epub/reader/ui/reader/ReviewPanel.kt
@@ -1,0 +1,325 @@
+package com.zhongbai233.epub.reader.ui.reader
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.zhongbai233.epub.reader.i18n.I18n
+import com.zhongbai233.epub.reader.model.ContentBlock
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * 解析段评文本为结构化数据
+ * 格式: "1. 【内容】 作者：xxx | 时间：xxx | 赞：52"
+ */
+private data class ReviewCard(
+    val index: Int,
+    val content: String,
+    val author: String,
+    val timestamp: String,
+    val likes: Int
+)
+
+private fun parseReviewCard(text: String): ReviewCard? {
+    val trimmed = text.trim()
+    val dotPos = trimmed.indexOf('.')
+    if (dotPos <= 0) return null
+    val index = trimmed.substring(0, dotPos).trim().toIntOrNull() ?: return null
+    val rest = trimmed.substring(dotPos + 1).trim()
+
+    val parts = rest.split(Regex("[|｜]"))
+    if (parts.size < 3) return null
+
+    // Find likes — last part containing 赞:
+    val likesPart = parts.last().trim()
+    val likesStr = likesPart.removePrefix("赞：").removePrefix("赞:").trim()
+    val likes = likesStr.toIntOrNull() ?: return null
+
+    // Find timestamp — second-to-last part containing 时间:
+    val timePart = parts[parts.size - 2].trim()
+    val timestampRaw = timePart.removePrefix("时间：").removePrefix("时间:").trim()
+    if (timestampRaw == timePart) return null  // neither prefix found
+
+    // Find author and content — search all parts via regex to tolerate varied positions
+    val authorRegex = Regex("""(.*)作者[:：]\s*(.+)""")
+    var content = ""
+    var author: String? = null
+    for (part in parts) {
+        val m = authorRegex.find(part.trim()) ?: continue
+        content = m.groupValues[1].trim()
+        author = m.groupValues[2].trim()
+        break
+    }
+    if (author == null) return null
+
+    return ReviewCard(index, content, author, timestampRaw, likes)
+}
+
+private fun formatTimestamp(s: String): String {
+    val ts = s.toLongOrNull() ?: return s
+    return try {
+        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+        sdf.format(Date(ts * 1000))
+    } catch (_: Exception) {
+        s
+    }
+}
+
+/**
+ * 段评面板 — 底部弹层展示段评内容
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReviewPanel(
+    chapterTitle: String,
+    blocks: List<ContentBlock>,
+    anchorId: String? = null,
+    fontSize: Float = 16f,
+    onDismiss: () -> Unit
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    // 是否显示全部评论（当从锚点打开时，默认只显示当前段）
+    var showAll by remember(anchorId) { mutableStateOf(anchorId.isNullOrBlank()) }
+
+    // 根据 anchorId 和 showAll 筛选 blocks，同时去除重复的 "第X章 … - 段评" 标题
+    val filteredBlocks = remember(blocks, anchorId, showAll) {
+        val baseList = if (anchorId.isNullOrBlank() || showAll) {
+            blocks
+        } else {
+            val result = mutableListOf<ContentBlock>()
+            var inTargetSection = false
+            for (block in blocks) {
+                if (block is ContentBlock.Heading && block.anchorId == anchorId) {
+                    inTargetSection = true
+                    result.add(block)
+                    continue
+                }
+                if (block is ContentBlock.Heading && !block.anchorId.isNullOrBlank() && block.anchorId != anchorId) {
+                    inTargetSection = false
+                    continue
+                }
+                if (inTargetSection) {
+                    result.add(block)
+                }
+            }
+            if (result.isEmpty()) blocks else result
+        }
+        // 去重：每个 "第X章 … - 段评" 标题只保留首次出现
+        val seenTitles = mutableSetOf<String>()
+        baseList.filter { block ->
+            if (block is ContentBlock.Heading) {
+                val text = block.spans.joinToString("") { it.text }
+                if (text.endsWith(" - 段评")) seenTitles.add(text) else true
+            } else true
+        }
+    }
+
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        dragHandle = { BottomSheetDefaults.DragHandle() }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(0.80f)
+                .padding(horizontal = 16.dp)
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    I18n.t("review.panel_title"),
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        Icons.Default.Close,
+                        contentDescription = I18n.t("dialog.close")
+                    )
+                }
+            }
+
+            Text(
+                chapterTitle,
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp)
+            )
+
+            // 显示全部 / 只看当前段 切换按钮
+            if (!anchorId.isNullOrBlank()) {
+                TextButton(
+                    onClick = { showAll = !showAll },
+                    modifier = Modifier.padding(vertical = 2.dp)
+                ) {
+                    Text(
+                        if (showAll) "🔍 只看当前段" else "📖 显示全部",
+                        fontSize = 13.sp
+                    )
+                }
+            }
+
+            HorizontalDivider()
+            Spacer(Modifier.height(8.dp))
+
+            // Content
+            LazyColumn {
+                itemsIndexed(filteredBlocks, key = { index, _ -> index }) { _, block ->
+                    when (block) {
+                        is ContentBlock.Separator -> {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = 6.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                            )
+                        }
+                        is ContentBlock.BlankLine -> {
+                            Spacer(Modifier.height((fontSize * 0.4).dp))
+                        }
+                        is ContentBlock.Heading -> {
+                            val text = block.spans.joinToString("") { it.text }
+                            val size = when (block.level) {
+                                1 -> 17.sp
+                                2 -> 15.sp
+                                else -> 13.sp
+                            }
+                            Text(
+                                text = text,
+                                fontSize = size,
+                                fontWeight = FontWeight.Bold,
+                                modifier = Modifier.padding(vertical = 6.dp),
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                        is ContentBlock.Paragraph -> {
+                            val rawText = block.spans.joinToString("") { it.text }
+                            if (rawText.isBlank()) return@itemsIndexed
+
+                            val card = parseReviewCard(rawText)
+                            if (card != null) {
+                                // 结构化评论卡片
+                                ReviewCardItem(card = card, fontSize = fontSize)
+                            } else {
+                                // 普通文本（如"回到正文"链接）
+                                val formattedText = formatReviewTextFallback(rawText)
+                                OutlinedCard(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 3.dp),
+                                    colors = CardDefaults.cardColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+                                    ),
+                                    shape = MaterialTheme.shapes.medium,
+                                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+                                ) {
+                                    Text(
+                                        text = formattedText,
+                                        fontSize = fontSize.sp,
+                                        modifier = Modifier.padding(12.dp),
+                                        color = MaterialTheme.colorScheme.onSurface
+                                    )
+                                }
+                            }
+                        }
+                        is ContentBlock.Image -> {
+                            if (!block.alt.isNullOrBlank()) {
+                                Text(
+                                    text = block.alt,
+                                    fontSize = (fontSize * 0.9f).sp,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.65f),
+                                    modifier = Modifier.padding(vertical = 4.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewCardItem(card: ReviewCard, fontSize: Float) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        ),
+        shape = MaterialTheme.shapes.medium,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            // 作者名
+            Text(
+                text = card.author,
+                fontSize = (fontSize * 0.85f).sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Spacer(Modifier.height(4.dp))
+            // 评论内容
+            Text(
+                text = card.content,
+                fontSize = fontSize.sp,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+            Spacer(Modifier.height(6.dp))
+            // 时间和赞数
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = formatTimestamp(card.timestamp),
+                    fontSize = (fontSize * 0.75f).sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = "❤ ${card.likes}",
+                    fontSize = (fontSize * 0.75f).sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+}
+
+/**
+ * 兜底格式化：把文本中的 Unix 时间戳转换为可读日期（用于非结构化文本）
+ */
+private fun formatReviewTextFallback(text: String): String {
+    val regex = """时间[:：]\s*(\d{10})""".toRegex()
+    return regex.replace(text) { matchResult ->
+        val ts = matchResult.groupValues[1].toLongOrNull()
+        if (ts != null) {
+            try {
+                val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+                val dateStr = sdf.format(Date(ts * 1000))
+                "时间：${dateStr}"
+            } catch (_: Exception) {
+                matchResult.value
+            }
+        } else {
+            matchResult.value
+        }
+    }
+}

--- a/android/app/src/main/java/com/epub/reader/viewmodel/ReaderViewModel.kt
+++ b/android/app/src/main/java/com/epub/reader/viewmodel/ReaderViewModel.kt
@@ -35,6 +35,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.util.concurrent.ConcurrentHashMap
 import android.util.Base64
+import android.widget.Toast
 
 data class TxtChapterPreview(val title: String, val lineStart: Int, val charCount: Int)
 
@@ -68,7 +69,7 @@ class ReaderViewModel(application: Application) : AndroidViewModel(application) 
     var fontSize by mutableFloatStateOf(18f)
         private set
     var isDarkMode by mutableStateOf(false)
-    var isScrollMode by mutableStateOf(true)
+    var isScrollMode by mutableStateOf(false)
     var readerBgColorIndex by mutableIntStateOf(0)
         private set
     var readerCustomBgColorArgb by mutableIntStateOf(0xFFF5F0E8.toInt())
@@ -193,6 +194,15 @@ class ReaderViewModel(application: Application) : AndroidViewModel(application) 
         private set
     var showAnnotationsPanel by mutableStateOf(false)
 
+    // ---- 段评状态 ----
+    var reviewChapterIndices by mutableStateOf<Set<Int>>(emptySet())
+        private set
+    var chapterReviews by mutableStateOf<Map<Int, Int>>(emptyMap())
+        private set
+    var showReviewPanel by mutableStateOf(false)
+    var reviewPanelChapter by mutableStateOf<Int?>(null)
+    var reviewPanelAnchor by mutableStateOf<String?>(null)
+
     // ---- CSC 贡献状态 ----
     var showContributeDialog by mutableStateOf(false)
     var contributeStatus by mutableStateOf("")
@@ -315,7 +325,7 @@ class ReaderViewModel(application: Application) : AndroidViewModel(application) 
     private fun loadSettings() {
         fontSize = prefs.getFloat(PrefKeys.FONT_SIZE, 18f).coerceIn(12f, 40f)
         isDarkMode = prefs.getBoolean(PrefKeys.DARK_MODE, false)
-        isScrollMode = prefs.getBoolean(PrefKeys.SCROLL_MODE, true)
+        isScrollMode = prefs.getBoolean(PrefKeys.SCROLL_MODE, false)
 
         readerBgColorIndex = prefs.getInt(PrefKeys.BG_COLOR_INDEX, 0).coerceAtLeast(0)
         readerCustomBgColorArgb = prefs.getInt(PrefKeys.CUSTOM_BG_COLOR, 0xFFF5F0E8.toInt())
@@ -633,6 +643,27 @@ class ReaderViewModel(application: Application) : AndroidViewModel(application) 
                 ?: throw Exception("EPUB ����ʧ�� (Rust Bridge)")
             
             val metadata = jsonParser.decodeFromString<BookMetadataDto>(metadataJson)
+
+            // Parse review chapter info from DTO with safe fallback
+            val reviewIndices = try {
+                metadata.reviewChapterIndices.toMutableSet()
+            } catch (e: Exception) {
+                android.util.Log.e("ReaderViewModel", "解析段评数据失败", e)
+                mutableSetOf<Int>()
+            }
+            val chapterReviewMap = try {
+                metadata.chapterReviews.associate { it.main to it.review }.toMutableMap()
+            } catch (e: Exception) {
+                android.util.Log.e("ReaderViewModel", "解析段评数据失败", e)
+                mutableMapOf<Int, Int>()
+            }
+            withContext(Dispatchers.Main) {
+                reviewChapterIndices = reviewIndices
+                chapterReviews = chapterReviewMap
+                // Reset review panel state so a stale panel never persists across book switches
+                showReviewPanel = false
+                reviewPanelChapter = null
+            }
             
             val lazyChapters = object : AbstractList<Chapter>() {
                 val cache = ConcurrentHashMap<Int, Chapter>()
@@ -726,6 +757,9 @@ class ReaderViewModel(application: Application) : AndroidViewModel(application) 
         }
         currentChapter = target
         currentPage = 0
+        // Close review panel if open so a stale panel doesn't linger after TOC navigation
+        showReviewPanel = false
+        reviewPanelChapter = null
         saveProgress()
         updateBookmarkState()
         checkContributionPrompt()
@@ -744,22 +778,53 @@ class ReaderViewModel(application: Application) : AndroidViewModel(application) 
     fun nextChapter() {
         val book = currentBook ?: return
         if (currentChapter < book.chapters.size - 1) {
-            currentChapter++
-            currentPage = 0
-            saveProgress()
-            updateBookmarkState()
-            checkContributionPrompt()
+            var next = currentChapter + 1
+            // Skip review chapters
+            while (next < book.chapters.size && reviewChapterIndices.contains(next)) {
+                next++
+            }
+            if (next < book.chapters.size) {
+                currentChapter = next
+                currentPage = 0
+                saveProgress()
+                updateBookmarkState()
+                checkContributionPrompt()
+            } else {
+                Toast.makeText(context, I18n.t("reader.at_last_chapter"), Toast.LENGTH_SHORT).show()
+            }
         }
     }
 
     fun prevChapter() {
+        val book = currentBook ?: return
         if (currentChapter > 0) {
-            currentChapter--
-            currentPage = 0
-            saveProgress()
-            updateBookmarkState()
-            checkContributionPrompt()
+            var prev = currentChapter - 1
+            // Skip review chapters
+            while (prev >= 0 && reviewChapterIndices.contains(prev)) {
+                prev--
+            }
+            if (prev >= 0) {
+                currentChapter = prev
+                currentPage = 0
+                saveProgress()
+                updateBookmarkState()
+                checkContributionPrompt()
+            } else {
+                Toast.makeText(context, I18n.t("reader.at_first_chapter"), Toast.LENGTH_SHORT).show()
+            }
         }
+    }
+
+    fun openReviewPanel(chapterIndex: Int, anchor: String? = null) {
+        showReviewPanel = true
+        reviewPanelChapter = chapterIndex
+        reviewPanelAnchor = anchor
+    }
+
+    fun closeReviewPanel() {
+        showReviewPanel = false
+        reviewPanelChapter = null
+        reviewPanelAnchor = null
     }
 
     fun setPage(page: Int) {


### PR DESCRIPTION
## 功能：Android 段评面板 + 默认左右翻页

### 变更内容
- 新增 ReviewPanel.kt：底部弹层面板
  - 锚点筛选（默认只显示当前段落评论，可切换"显示全部"）
  - 卡片化展示：作者、内容、格式化时间、赞数
  - 解析 "1. 【内容】 作者：xxx | 时间：xxx | 赞：52" 格式
- ContentBlockView.kt：链接碰撞箱扩展（±30px），解决手指点偏问题
- ReaderScreen.kt：拦截段评链接，提取 #anchor
- ReaderViewModel.kt：默认 isScrollMode = false（左右翻页）
- build.gradle.kts：cargoBuild targets 增加 armeabi-v7a

### 合并顺序
**建议在第 1 个 PR（#15 core）之后合并**。此 PR 依赖 core 中的段评数据结构。

### 前置依赖
- #15 feat(core): 段评核心支持