### PR TITLE
fix(android): handle empty string env vars in release signing config

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -19,17 +19,17 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            val keystoreFile = System.getenv("ANDROID_KEYSTORE_FILE")
-                ?: project.findProperty("ANDROID_KEYSTORE_FILE") as String?
-            val ksAlias = System.getenv("ANDROID_KEY_ALIAS")
-                ?: project.findProperty("ANDROID_KEY_ALIAS") as String?
-            val ksPassword = System.getenv("ANDROID_STORE_PASSWORD")
-                ?: project.findProperty("ANDROID_STORE_PASSWORD") as String?
-            val kPassword = System.getenv("ANDROID_KEY_PASSWORD")
-                ?: project.findProperty("ANDROID_KEY_PASSWORD") as String?
+        val keystoreFile = System.getenv("ANDROID_KEYSTORE_FILE")
+            ?: project.findProperty("ANDROID_KEYSTORE_FILE") as String?
+        val ksAlias = System.getenv("ANDROID_KEY_ALIAS")
+            ?: project.findProperty("ANDROID_KEY_ALIAS") as String?
+        val ksPassword = System.getenv("ANDROID_STORE_PASSWORD")
+            ?: project.findProperty("ANDROID_STORE_PASSWORD") as String?
+        val kPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            ?: project.findProperty("ANDROID_KEY_PASSWORD") as String?
 
-            if (keystoreFile != null && ksAlias != null) {
+        if (!keystoreFile.isNullOrBlank() && !ksAlias.isNullOrBlank()) {
+            create("release") {
                 storeFile = file(keystoreFile)
                 keyAlias = ksAlias
                 storePassword = ksPassword


### PR DESCRIPTION
## Problem

The `Build Android APK` CI job fails with:

```
Cannot convert '' to File.
Build file '.../android/app/build.gradle.kts' line: 33
```

## Root Cause

The GitHub Actions workflow sets `ANDROID_KEYSTORE_FILE` via:

```yaml
ANDROID_KEYSTORE_FILE: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' && 'release.keystore' || '' }}
```

When the signing secret is absent, this produces an **empty string** instead of leaving the variable unset. `System.getenv()` then returns `""` rather than `null`, so the existing `!= null` check passes and `file("")` throws.

## Fix

Replace `!= null` with `isNullOrBlank()` to guard against both `null` and empty strings in signing configuration environment variables.
