### PR TITLE
[BUG] 修复: 阅读字体切换时中文标点未同步

### DIFF
--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -20,6 +20,14 @@ use reader_core::sharing::{start_listener, DiscoveredPeer, PeerStore};
 type FontDiscoveryResult = Arc<Mutex<Option<(Vec<String>, HashMap<String, String>)>>>;
 pub(crate) type TtsAudioResultSlot = Arc<Mutex<Option<Result<Vec<u8>, String>>>>;
 
+fn extend_unique_font_chain(target: &mut Vec<String>, fonts: impl IntoIterator<Item = String>) {
+    for font in fonts {
+        if !target.contains(&font) {
+            target.push(font);
+        }
+    }
+}
+
 /// Push a debug log entry from anywhere (including background threads).
 /// Writes to both the in-memory feedback_logs buffer and stderr (when debug logging is enabled).
 pub fn dbg_log(logs: &Arc<Mutex<Vec<String>>>, msg: impl AsRef<str>) {
@@ -1981,6 +1989,11 @@ impl eframe::App for ReaderApp {
                 .get(&egui::FontFamily::Proportional)
                 .cloned()
                 .unwrap_or_default();
+            let default_monospace = fonts
+                .families
+                .get(&egui::FontFamily::Monospace)
+                .cloned()
+                .unwrap_or_default();
 
             let mut selected_latin_bound = matches!(
                 self.reader_font_family.as_str(),
@@ -2161,57 +2174,68 @@ impl eframe::App for ReaderApp {
                 }
             }
 
-            // Build "ReaderFont" composite family: Latin fonts → CJK fonts → emoji
-            let mut reader_font_chain: Vec<String> = Vec::new();
-
-            // Latin part
+            // Build separate Latin-first and CJK-first reader families. egui picks the first
+            // font containing each glyph, so one shared chain lets Latin fonts consume CJK
+            // punctuation before the user's selected CJK font gets a chance to render it.
+            let mut reader_latin_fonts = Vec::new();
             match self.reader_font_family.as_str() {
-                "Sans" => reader_font_chain.extend(default_proportional.clone()),
+                "Sans" => {
+                    extend_unique_font_chain(&mut reader_latin_fonts, default_proportional.clone())
+                }
                 "Serif" => {
                     if fonts.font_data.contains_key("serif_font") {
-                        reader_font_chain.push("serif_font".to_owned());
+                        reader_latin_fonts.push("serif_font".to_owned());
                     }
-                    reader_font_chain.extend(default_proportional.clone());
+                    extend_unique_font_chain(&mut reader_latin_fonts, default_proportional.clone());
                 }
                 "Monospace" => {
-                    if let Some(mono) = fonts.families.get(&egui::FontFamily::Monospace) {
-                        reader_font_chain.extend(mono.clone());
-                    }
+                    extend_unique_font_chain(&mut reader_latin_fonts, default_monospace.clone());
                 }
                 other => {
                     if fonts.font_data.contains_key(other) {
-                        reader_font_chain.push(other.to_owned());
+                        reader_latin_fonts.push(other.to_owned());
                     }
-                    reader_font_chain.extend(default_proportional.clone());
+                    extend_unique_font_chain(&mut reader_latin_fonts, default_proportional.clone());
                 }
             }
 
-            // CJK part
+            let mut reader_cjk_fonts = Vec::new();
             match self.reader_cjk_font_family.as_str() {
                 "Sans" => {
                     if fonts.font_data.contains_key("cjk_font") {
-                        reader_font_chain.push("cjk_font".to_owned());
+                        reader_cjk_fonts.push("cjk_font".to_owned());
                     }
                 }
                 other => {
                     if fonts.font_data.contains_key(other) {
-                        reader_font_chain.push(other.to_owned());
+                        reader_cjk_fonts.push(other.to_owned());
                     }
                     if fonts.font_data.contains_key("cjk_font") {
-                        reader_font_chain.push("cjk_font".to_owned());
+                        reader_cjk_fonts.push("cjk_font".to_owned());
                     }
                 }
             }
 
-            // Emoji
+            let mut emoji_fallback = Vec::new();
             if fonts.font_data.contains_key("emoji_font") {
-                reader_font_chain.push("emoji_font".to_owned());
+                emoji_fallback.push("emoji_font".to_owned());
             }
+
+            let mut reader_font_chain = reader_latin_fonts.clone();
+            extend_unique_font_chain(&mut reader_font_chain, reader_cjk_fonts.clone());
+            extend_unique_font_chain(&mut reader_font_chain, emoji_fallback.clone());
+
+            let mut reader_cjk_chain = reader_cjk_fonts.clone();
+            extend_unique_font_chain(&mut reader_cjk_chain, reader_latin_fonts.clone());
+            extend_unique_font_chain(&mut reader_cjk_chain, emoji_fallback.clone());
 
             fonts.families.insert(
                 egui::FontFamily::Name("ReaderFont".into()),
                 reader_font_chain,
             );
+            fonts
+                .families
+                .insert(egui::FontFamily::Name("ReaderCjk".into()), reader_cjk_chain);
 
             ctx.set_fonts(fonts);
             self.pages_dirty = true;

--- a/desktop/src/ui/reader_block.rs
+++ b/desktop/src/ui/reader_block.rs
@@ -8,6 +8,72 @@ use reader_core::epub::{ContentBlock, InlineStyle, TextSpan};
 
 use super::reader_state::*;
 
+fn family_from_name(name: &str) -> FontFamily {
+    match name {
+        "Monospace" => FontFamily::Monospace,
+        "Serif" => FontFamily::Name("Serif".into()),
+        "Sans" => FontFamily::Proportional,
+        other => FontFamily::Name(other.into()),
+    }
+}
+
+fn uses_cjk_font(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        0x3400..=0x4DBF
+            | 0x4E00..=0x9FFF
+            | 0xF900..=0xFAFF
+            | 0x3040..=0x30FF
+            | 0x2018
+            | 0x2019
+            | 0x201C
+            | 0x201D
+            | 0x3000..=0x303F
+            | 0xFE10..=0xFE1F
+            | 0xFE30..=0xFE4F
+            | 0xFF01..=0xFF65
+    )
+}
+
+fn append_font_runs(
+    job: &mut LayoutJob,
+    text: &str,
+    leading: f32,
+    base_format: TextFormat,
+    cjk_family: &FontFamily,
+) {
+    if base_format.font_id.family == *cjk_family {
+        job.append(text, leading, base_format);
+        return;
+    }
+    let mut chars = text.char_indices();
+    let Some((_, first)) = chars.next() else {
+        return;
+    };
+    let mut run_start = 0;
+    let mut run_is_cjk = uses_cjk_font(first);
+    let mut first_run = true;
+
+    for (index, ch) in chars.chain(std::iter::once((text.len(), '\0'))) {
+        let is_cjk = index < text.len() && uses_cjk_font(ch);
+        if index < text.len() && is_cjk == run_is_cjk {
+            continue;
+        }
+        let mut format = base_format.clone();
+        if run_is_cjk {
+            format.font_id = FontId::new(format.font_id.size, cjk_family.clone());
+        }
+        job.append(
+            &text[run_start..index],
+            if first_run { leading } else { 0.0 },
+            format,
+        );
+        first_run = false;
+        run_start = index;
+        run_is_cjk = is_cjk;
+    }
+}
+
 // ── Content layout (was `ReaderApp::render_content_layout`, no `&self`) ──
 
 #[allow(clippy::too_many_arguments)]
@@ -53,12 +119,7 @@ pub(crate) fn render_content_layout(
                     ui.set_max_width(text_width);
                     if show_title {
                         let title_color = effective_text_color(bg_color, font_color);
-                        let title_family = match font_family_name {
-                            "Monospace" => FontFamily::Monospace,
-                            "Serif" => FontFamily::Name("Serif".into()),
-                            "Sans" => FontFamily::Proportional,
-                            other => FontFamily::Name(other.into()),
-                        };
+                        let title_family = family_from_name(font_family_name);
                         ui.vertical_centered(|ui| {
                             ui.label(
                                 egui::RichText::new(title)
@@ -649,12 +710,12 @@ pub(crate) fn build_layout_job(
         let family = if is_bold {
             FontFamily::Name("Bold".into())
         } else {
-            match font_family_name {
-                "Monospace" => FontFamily::Monospace,
-                "Serif" => FontFamily::Name("Serif".into()),
-                "Sans" => FontFamily::Proportional,
-                other => FontFamily::Name(other.into()),
-            }
+            family_from_name(font_family_name)
+        };
+        let cjk_family = if !is_bold && font_family_name == "ReaderFont" {
+            FontFamily::Name("ReaderCjk".into())
+        } else {
+            family.clone()
         };
         let normal_color = if is_link { link_color } else { base_color };
         let leading = if i == 0 && !is_heading {
@@ -690,7 +751,7 @@ pub(crate) fn build_layout_job(
                 line_height: Some(font_size * line_spacing()),
                 ..Default::default()
             };
-            job.append(&wrapped, leading, format);
+            append_font_runs(&mut job, &wrapped, leading, format, &cjk_family);
         } else {
             // Split span text at highlight boundaries
             let mut first_section = true;
@@ -728,7 +789,7 @@ pub(crate) fn build_layout_job(
                         ..Default::default()
                     };
                     let lead = if first_section { leading } else { 0.0 };
-                    job.append(&seg_text, lead, format);
+                    append_font_runs(&mut job, &seg_text, lead, format, &cjk_family);
                     first_section = false;
                     seg_start = j;
                     cur_hl = this_hl;
@@ -755,7 +816,7 @@ pub(crate) fn build_layout_job(
                 ..Default::default()
             };
             let lead = if first_section { leading } else { 0.0 };
-            job.append(&seg_text, lead, format);
+            append_font_runs(&mut job, &seg_text, lead, format, &cjk_family);
         }
 
         char_offset = span_end;
@@ -811,5 +872,68 @@ pub(crate) fn estimate_block_height(
         ContentBlock::Separator => 24.0,
         ContentBlock::BlankLine => font_size * 0.5,
         ContentBlock::Image { .. } => font_size * 3.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routes_only_cjk_characters_and_punctuation_to_cjk_font() {
+        for ch in "中文日本語？！：；，。、“”‘’「」".chars() {
+            assert!(uses_cjk_font(ch), "{ch} should use ReaderCjk");
+        }
+        for ch in "English?!:;\"'😀".chars() {
+            assert!(!uses_cjk_font(ch), "{ch} should use ReaderFont");
+        }
+    }
+
+    #[test]
+    fn layout_job_groups_script_runs_into_reader_families() {
+        let mut job = LayoutJob::default();
+        append_font_runs(
+            &mut job,
+            "中文？ English?",
+            0.0,
+            TextFormat {
+                font_id: FontId::new(18.0, FontFamily::Name("ReaderFont".into())),
+                ..Default::default()
+            },
+            &FontFamily::Name("ReaderCjk".into()),
+        );
+
+        let families: Vec<String> = job
+            .sections
+            .iter()
+            .map(|section| match &section.format.font_id.family {
+                FontFamily::Name(name) => name.to_string(),
+                other => format!("{other:?}"),
+            })
+            .collect();
+        assert_eq!(families, ["ReaderCjk", "ReaderFont"]);
+    }
+
+    #[test]
+    fn highlighted_punctuation_keeps_cjk_font() {
+        let spans = [TextSpan {
+            text: "你好！”".to_owned(),
+            style: InlineStyle::Normal,
+            link_url: None,
+            correction: None,
+        }];
+        let job = build_layout_job(
+            &spans,
+            18.0,
+            Color32::WHITE,
+            false,
+            600.0,
+            None,
+            "ReaderFont",
+            &[(0, 3, reader_core::library::HighlightColor::Yellow)],
+        );
+        assert!(job.sections.iter().all(|section| {
+            section.format.font_id.family == FontFamily::Name("ReaderCjk".into())
+        }));
     }
 }


### PR DESCRIPTION
## 分类

- [x] BUG 修复（bug）

## 变更内容概述

切换阅读字体时，使中文全角标点与 CJK 正文使用同一字体链，并保留字体 fallback。

## 影响平台

- [x] Desktop (Linux) 在linux中存在该问题，其他平台未确认

## 验证方式

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p rust_epub_reader --all-targets`
- [x] `cargo test -p rust_epub_reader`（15 项通过）
- [x] Linux Release 编译通过

## 兼容性/风险评估

该实现仅作为一种可能的修复路径。不同字体的字形覆盖范围和 fallback 行为存在差异，可能引入新的中英文混排或特殊字符显示问题；维护者可以考虑采用其他修复方式。
