### PR TITLE
[Feature] 改进 TTS 连续朗读与定位

### DIFF
--- a/core/src/i18n/en.json
+++ b/core/src/i18n/en.json
@@ -255,6 +255,8 @@
   "tts.pause": "⏸ Pause",
   "tts.resume": "▶ Resume",
   "tts.stop": "⏹ Stop",
+  "tts.read_from_here": "Read aloud from here",
+  "tts.follow_reading": "Follow current narration",
   "tts.synthesizing": "Synthesizing…",
   "tts.playing": "Playing…",
   "tts.paused": "Paused",

--- a/core/src/i18n/zh_cn.json
+++ b/core/src/i18n/zh_cn.json
@@ -255,6 +255,8 @@
   "tts.pause": "⏸ 暂停",
   "tts.resume": "▶ 继续",
   "tts.stop": "⏹ 停止",
+  "tts.read_from_here": "从此处开始朗读",
+  "tts.follow_reading": "跟随阅读",
   "tts.synthesizing": "合成中…",
   "tts.playing": "正在朗读…",
   "tts.paused": "已暂停",

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -627,6 +627,7 @@ pub struct ReaderApp {
     pub tts_volume: i32, // e.g. 0, -50, +50 (percent)
     pub tts_current_chapter: usize,
     pub tts_current_block: usize,
+    pub tts_current_char: usize,
     pub tts_stop_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
     pub tts_generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
     pub tts_audio_sink: Option<std::sync::Arc<rodio::Sink>>,
@@ -914,6 +915,7 @@ impl Default for ReaderApp {
             tts_volume: 0,
             tts_current_chapter: 0,
             tts_current_block: 0,
+            tts_current_char: 0,
             tts_stop_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
             tts_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
             tts_audio_sink: None,

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -625,8 +625,10 @@ pub struct ReaderApp {
     pub tts_voice_name: String,
     pub tts_rate: i32,   // e.g. 0, -20, +50 (percent)
     pub tts_volume: i32, // e.g. 0, -50, +50 (percent)
+    pub tts_current_chapter: usize,
     pub tts_current_block: usize,
     pub tts_stop_flag: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    pub tts_generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
     pub tts_audio_sink: Option<std::sync::Arc<rodio::Sink>>,
     pub tts_output_stream: Option<rodio::OutputStream>,
     pub tts_output_handle: Option<rodio::OutputStreamHandle>,
@@ -635,8 +637,13 @@ pub struct ReaderApp {
     pub tts_pending_audio: Option<TtsAudioResultSlot>,
     /// Prefetched audio for the next block (ready to play immediately when current finishes).
     pub tts_prefetch_audio: Option<TtsAudioResultSlot>,
-    /// Block index that the prefetch corresponds to.
+    /// Chapter and block that the prefetch corresponds to.
+    pub tts_prefetch_chapter: usize,
     pub tts_prefetch_block: usize,
+    /// Keep the reader viewport aligned with the current TTS block.
+    pub tts_follow_view: bool,
+    /// Prevent TTS-driven page/chapter navigation from detaching the viewport.
+    pub tts_syncing_navigation: bool,
     pub last_egui_ctx: Option<egui::Context>,
     // ── API Settings ──
     pub translate_api_url: String,
@@ -905,8 +912,10 @@ impl Default for ReaderApp {
             tts_voice_name: "zh-CN-XiaoxiaoNeural".to_string(),
             tts_rate: 0,
             tts_volume: 0,
+            tts_current_chapter: 0,
             tts_current_block: 0,
             tts_stop_flag: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            tts_generation: std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
             tts_audio_sink: None,
             tts_output_stream: None,
             tts_output_handle: None,
@@ -914,7 +923,10 @@ impl Default for ReaderApp {
             show_tts_panel: false,
             tts_pending_audio: None,
             tts_prefetch_audio: None,
+            tts_prefetch_chapter: 0,
             tts_prefetch_block: 0,
+            tts_follow_view: false,
+            tts_syncing_navigation: false,
             last_egui_ctx: None,
             // API settings
             translate_api_url: String::new(),
@@ -1032,6 +1044,7 @@ impl Default for ReaderApp {
 
 impl ReaderApp {
     pub fn trigger_page_animation_to(&mut self, target_page: usize, direction: f32) {
+        let page_changed = target_page != self.current_page;
         if self.reader_page_animation == "None"
             || self.scroll_mode
             || target_page == self.current_page
@@ -1040,6 +1053,9 @@ impl ReaderApp {
             self.page_anim_progress = 1.0;
             self.page_anim_from = target_page;
             self.page_anim_to = target_page;
+            if page_changed {
+                self.tts_detach_view();
+            }
             return;
         }
 
@@ -1053,6 +1069,7 @@ impl ReaderApp {
         self.page_anim_progress = 0.0;
         self.page_anim_cross_chapter = false;
         self.current_page = target_page;
+        self.tts_detach_view();
     }
 
     pub fn pick_reader_background_image(&mut self) {
@@ -1239,6 +1256,7 @@ impl ReaderApp {
             }
             // Check if user should be prompted to contribute
             self.csc_check_contribution_prompt();
+            self.tts_detach_view();
         }
     }
 
@@ -1270,6 +1288,7 @@ impl ReaderApp {
             }
             // Check if user should be prompted to contribute
             self.csc_check_contribution_prompt();
+            self.tts_detach_view();
         }
     }
 

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -82,8 +82,16 @@ impl ReaderApp {
         // Clear per-frame block galley cache
         BLOCK_GALLEYS.with(|bg| bg.borrow_mut().clear());
 
+        if self.tts_playing
+            && self.current_chapter != self.tts_current_chapter
+            && !self.tts_syncing_navigation
+        {
+            self.tts_detach_view();
+        }
+
         // Set TTS read-along highlight block
-        if self.tts_playing && !self.tts_paused {
+        if self.tts_playing && !self.tts_paused && self.current_chapter == self.tts_current_chapter
+        {
             TTS_HIGHLIGHT_BLOCK.set(Some(self.tts_current_block));
         } else {
             TTS_HIGHLIGHT_BLOCK.set(None);
@@ -213,6 +221,11 @@ impl ReaderApp {
                     .unwrap_or_default();
 
                 if self.scroll_mode {
+                    if ui.rect_contains_pointer(ui.available_rect_before_wrap())
+                        && ui.input(|i| i.raw_scroll_delta.y != 0.0)
+                    {
+                        self.tts_detach_view();
+                    }
                     let mut scroll_area = egui::ScrollArea::vertical().auto_shrink([false; 2]);
                     if self.scroll_to_top {
                         scroll_area = scroll_area.vertical_scroll_offset(0.0);
@@ -251,7 +264,9 @@ impl ReaderApp {
                                     .iter()
                                     .find(|(idx, _, _, _)| *idx == target)
                                 {
-                                    ui.scroll_to_rect(*rect, Some(egui::Align::Min));
+                                    if !rect.intersects(ui.clip_rect()) {
+                                        ui.scroll_to_rect(*rect, Some(egui::Align::Min));
+                                    }
                                     self.pending_restore_block = None;
                                 }
                             });

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -259,10 +259,10 @@ impl ReaderApp {
                         );
                         if let Some(target) = self.pending_restore_block {
                             BLOCK_GALLEYS.with(|galleys| {
-                                if let Some((_, _, rect, _)) = galleys
+                                if let Some((_, _, rect, _, _)) = galleys
                                     .borrow()
                                     .iter()
-                                    .find(|(idx, _, _, _)| *idx == target)
+                                    .find(|(idx, _, _, _, _)| *idx == target)
                                 {
                                     if !rect.intersects(ui.clip_rect()) {
                                         ui.scroll_to_rect(*rect, Some(egui::Align::Min));
@@ -277,9 +277,9 @@ impl ReaderApp {
                         galleys
                             .borrow()
                             .iter()
-                            .filter(|(_, _, rect, _)| rect.intersects(viewport))
+                            .filter(|(_, _, rect, _, _)| rect.intersects(viewport))
                             .min_by(|a, b| a.2.top().total_cmp(&b.2.top()))
-                            .map(|(idx, _, _, _)| *idx)
+                            .map(|(idx, _, _, _, _)| *idx)
                     });
                     if let Some(block) = visible_block {
                         self.schedule_position_save(block);
@@ -1140,6 +1140,53 @@ impl ReaderApp {
         let block_galleys: Vec<BlockGalleyEntry> =
             BLOCK_GALLEYS.with(|bg| bg.borrow_mut().drain(..).collect());
 
+        let mut start_reading = None;
+        let mut follow_reading = false;
+        let mut tts_context_menu_open = false;
+        for (block_idx, galley, rect, _, response) in &block_galleys {
+            let target_id = response.id.with("tts_read_from_here");
+            if response.secondary_clicked() {
+                if let Some(pos) = response.interact_pointer_pos() {
+                    let cursor = galley.cursor_from_pos(pos - rect.min);
+                    ui.ctx().data_mut(|data| {
+                        data.insert_temp(
+                            target_id,
+                            (self.current_chapter, *block_idx, cursor.ccursor.index),
+                        );
+                    });
+                }
+            }
+            let target = ui
+                .ctx()
+                .data(|data| data.get_temp::<(usize, usize, usize)>(target_id));
+            let was_open = response.context_menu_opened();
+            response.context_menu(|ui| {
+                if let Some(target) = target {
+                    if ui.button(self.i18n.t("tts.read_from_here")).clicked() {
+                        start_reading = Some(target);
+                        ui.close_menu();
+                    }
+                }
+                if ui
+                    .add_enabled(
+                        self.tts_playing && !self.tts_follow_view,
+                        egui::Button::new(self.i18n.t("tts.follow_reading")),
+                    )
+                    .clicked()
+                {
+                    follow_reading = true;
+                    ui.close_menu();
+                }
+            });
+            tts_context_menu_open |= was_open || response.context_menu_opened();
+        }
+        if let Some((chapter, block_idx, char_offset)) = start_reading {
+            self.show_tts_panel = true;
+            self.tts_start_from_position(chapter, block_idx, char_offset);
+        } else if follow_reading {
+            self.tts_follow_playback();
+        }
+
         // Detect primary pointer press / drag / release for selection
         let pointer_pos = ui.ctx().input(|i| i.pointer.interact_pos());
         let primary_down = ui.ctx().input(|i| i.pointer.primary_down());
@@ -1148,7 +1195,7 @@ impl ReaderApp {
 
         // Helper: find which block a screen position falls into and return (block_idx, char_offset)
         let hit_test = |pos: egui::Pos2| -> Option<(usize, usize)> {
-            for (idx, galley, rect, _text) in &block_galleys {
+            for (idx, galley, rect, _text, _) in &block_galleys {
                 if rect.contains(pos) {
                     let local = egui::vec2(pos.x - rect.min.x, pos.y - rect.min.y);
                     let cursor = galley.cursor_from_pos(local);
@@ -1169,7 +1216,7 @@ impl ReaderApp {
         if let Some(pos) = pointer_pos {
             const DRAG_THRESHOLD: f32 = 5.0;
 
-            if primary_pressed && !over_toolbar {
+            if primary_pressed && !over_toolbar && !tts_context_menu_open {
                 if let Some((block_idx, char_idx)) = hit_test(pos) {
                     // Record press origin; don't create TextSelection yet
                     self.sel_press_origin = Some((pos, block_idx, char_idx));
@@ -1186,7 +1233,7 @@ impl ReaderApp {
                     self.text_selection = None;
                     self.clicked_highlight_id = None;
                 }
-            } else if primary_down && !over_toolbar {
+            } else if primary_down && !over_toolbar && !tts_context_menu_open {
                 // If we have a pending press origin but no selection yet, check threshold
                 if let Some((origin, block_idx, char_idx)) = self.sel_press_origin {
                     if (pos - origin).length() >= DRAG_THRESHOLD {
@@ -1212,7 +1259,7 @@ impl ReaderApp {
                             // Pointer is outside any block 鈥?find the closest block
                             // above or below to extend selection
                             let mut best: Option<(usize, usize)> = None;
-                            for (idx, galley, rect, _) in &block_galleys {
+                            for (idx, galley, rect, _, _) in &block_galleys {
                                 if pos.y < rect.min.y {
                                     // Above this block 鈫?first char
                                     if best.as_ref().is_none_or(|(best_idx, _)| *idx < *best_idx) {
@@ -1234,7 +1281,7 @@ impl ReaderApp {
                 }
             }
 
-            if primary_released {
+            if primary_released && !tts_context_menu_open {
                 // Check if this was a click (no drag) on a highlighted region
                 let mut handled_as_highlight = false;
                 if let Some((press_pos, press_block, press_char)) = self.sel_press_origin.take() {
@@ -1257,9 +1304,9 @@ impl ReaderApp {
                                 self.editing_note_buf.clear();
                             }
                             // Position popup above the click point
-                            if let Some((_, _, rect, _)) = block_galleys
+                            if let Some((_, _, rect, _, _)) = block_galleys
                                 .iter()
-                                .find(|(idx, _, _, _)| *idx == press_block)
+                                .find(|(idx, _, _, _, _)| *idx == press_block)
                             {
                                 self.hl_note_toolbar_pos = egui::pos2(rect.center().x, rect.min.y);
                             }
@@ -1324,9 +1371,9 @@ impl ReaderApp {
                         } else {
                             // Position the toolbar above the start of the selection
                             let (sel_start_block, _) = sel.normalized();
-                            if let Some((_, _, rect, _)) = block_galleys
+                            if let Some((_, _, rect, _, _)) = block_galleys
                                 .iter()
-                                .find(|(idx, _, _, _)| *idx == sel_start_block)
+                                .find(|(idx, _, _, _, _)| *idx == sel_start_block)
                             {
                                 self.sel_toolbar_pos = egui::pos2(rect.center().x, rect.top());
                             }
@@ -1339,7 +1386,7 @@ impl ReaderApp {
         // 鈹€鈹€ Draw selection highlight overlay (blue rectangles) 鈹€鈹€
         if let Some(sel) = &self.text_selection {
             let (sb, sc, eb, ec) = sel.normalized_range();
-            for (idx, galley, rect, text) in &block_galleys {
+            for (idx, galley, rect, text, _) in &block_galleys {
                 if *idx < sb || *idx > eb {
                     continue;
                 }
@@ -1393,7 +1440,7 @@ impl ReaderApp {
             .map(|sel| {
                 let (sb, sc, eb, ec) = sel.normalized_range();
                 let mut result = String::new();
-                for (idx, _, _, text) in &block_galleys {
+                for (idx, _, _, text, _) in &block_galleys {
                     if *idx < sb || *idx > eb {
                         continue;
                     }
@@ -1443,7 +1490,7 @@ impl ReaderApp {
                         let sel_range = sel.normalized_range();
                         if let Some(cfg) = &mut self.book_config {
                             let (sb, sc, eb, ec) = sel_range;
-                            for (idx, _, _, text) in &block_galleys {
+                            for (idx, _, _, text, _) in &block_galleys {
                                 if *idx < sb || *idx > eb {
                                     continue;
                                 }
@@ -1540,7 +1587,7 @@ impl ReaderApp {
                     // Create correction records for each selected character
                     let (sb, sc, eb, ec) = sel_range;
                     let replace_chars: Vec<char> = self.csc_custom_replace_buf.chars().collect();
-                    for (idx, _, _, block_text) in &block_galleys {
+                    for (idx, _, _, block_text, _) in &block_galleys {
                         if *idx < sb || *idx > eb {
                             continue;
                         }

--- a/desktop/src/ui/reader_block.rs
+++ b/desktop/src/ui/reader_block.rs
@@ -201,6 +201,17 @@ pub(crate) fn render_block(
             ui.painter()
                 .galley(rect.min, galley.clone(), Color32::PLACEHOLDER);
 
+            let text: String = spans.iter().map(|span| span.text.as_str()).collect();
+            BLOCK_GALLEYS.with(|galleys| {
+                galleys.borrow_mut().push((
+                    chapter_block_idx,
+                    galley.clone(),
+                    rect,
+                    text,
+                    response.clone(),
+                ));
+            });
+
             // Handle individual link clicks via pointer position matching
             if let Some(hover_pos) = ui.ctx().pointer_hover_pos() {
                 if rect.contains(hover_pos) {
@@ -455,8 +466,13 @@ pub(crate) fn render_block(
 
             // Push into per-frame cache for the selection state machine
             BLOCK_GALLEYS.with(|bg| {
-                bg.borrow_mut()
-                    .push((chapter_block_idx, galley.clone(), rect, text.clone()));
+                bg.borrow_mut().push((
+                    chapter_block_idx,
+                    galley.clone(),
+                    rect,
+                    text.clone(),
+                    response.clone(),
+                ));
             });
 
             // Handle individual link clicks via pointer position matching

--- a/desktop/src/ui/reader_state.rs
+++ b/desktop/src/ui/reader_state.rs
@@ -36,7 +36,7 @@ pub(crate) fn text_indent() -> f32 {
 // ── Thread-local deferred actions & per-frame block galley cache ──
 
 /// Per-frame cache entry: (block_idx, galley, screen_rect, plain_text)
-pub(crate) type BlockGalleyEntry = (usize, Arc<egui::Galley>, egui::Rect, String);
+pub(crate) type BlockGalleyEntry = (usize, Arc<egui::Galley>, egui::Rect, String, egui::Response);
 
 pub(crate) type CscCharMapCacheData = (u64, u32, u32, Vec<usize>);
 

--- a/desktop/src/ui/tts.rs
+++ b/desktop/src/ui/tts.rs
@@ -60,6 +60,10 @@ fn next_readable_block(blocks: &[ContentBlock], from: usize) -> usize {
         .map_or(blocks.len(), |offset| from + offset)
 }
 
+fn text_from_char(text: &str, char_offset: usize) -> String {
+    text.chars().skip(char_offset).collect()
+}
+
 impl ReaderApp {
     /// Render TTS as a horizontal bar between toolbar and content (Edge-style).
     pub fn render_tts_bar(&mut self, ctx: &egui::Context) {
@@ -258,10 +262,15 @@ impl ReaderApp {
                 .map(|(start, _)| *start)
                 .unwrap_or(self.current_block)
         };
-        self.tts_start_from_block(self.current_chapter, start_block);
+        self.tts_start_from_position(self.current_chapter, start_block, 0);
     }
 
-    fn tts_start_from_block(&mut self, chapter: usize, block: usize) {
+    pub(crate) fn tts_start_from_position(
+        &mut self,
+        chapter: usize,
+        block: usize,
+        char_offset: usize,
+    ) {
         self.tts_cancel_audio();
         self.tts_stop_flag.store(false, Ordering::Relaxed);
         self.tts_playing = true;
@@ -269,6 +278,11 @@ impl ReaderApp {
         self.tts_follow_view = true;
         self.tts_current_chapter = chapter;
         self.tts_current_block = self.tts_next_readable_block(chapter, block);
+        self.tts_current_char = if self.tts_current_block == block {
+            char_offset
+        } else {
+            0
+        };
         if let Some(total) = self.tts_block_count(chapter) {
             self.push_feedback_log(format!(
                 "[TTS] chapter {} has {} blocks, first readable={}",
@@ -307,6 +321,13 @@ impl ReaderApp {
         if self.tts_playing && !self.tts_syncing_navigation {
             self.tts_follow_view = false;
             self.pending_restore_block = None;
+        }
+    }
+
+    pub(crate) fn tts_follow_playback(&mut self) {
+        if self.tts_playing {
+            self.tts_follow_view = true;
+            self.tts_follow_current_position();
         }
     }
 
@@ -409,6 +430,7 @@ impl ReaderApp {
         };
         self.tts_current_chapter = chapter;
         self.tts_current_block = block;
+        self.tts_current_char = 0;
         self.tts_follow_current_position();
 
         // Check if we have prefetched audio for this block
@@ -453,7 +475,10 @@ impl ReaderApp {
             sink.stop();
         }
 
-        let text = self.tts_block_text(self.tts_current_chapter, self.tts_current_block);
+        let text = text_from_char(
+            &self.tts_block_text(self.tts_current_chapter, self.tts_current_block),
+            self.tts_current_char,
+        );
         if text.trim().is_empty() {
             self.tts_advance_to_next_block();
             return;
@@ -641,7 +666,7 @@ impl ReaderApp {
 
 #[cfg(test)]
 mod tests {
-    use super::{next_readable_block, page_for_block};
+    use super::{next_readable_block, page_for_block, text_from_char};
     use reader_core::epub::ContentBlock;
 
     #[test]
@@ -664,5 +689,10 @@ mod tests {
         ];
         assert_eq!(next_readable_block(&blocks, 0), 2);
         assert_eq!(next_readable_block(&blocks, 3), 3);
+    }
+
+    #[test]
+    fn starts_text_at_unicode_character_offset() {
+        assert_eq!(text_from_char("中文，English!", 3), "English!");
     }
 }

--- a/desktop/src/ui/tts.rs
+++ b/desktop/src/ui/tts.rs
@@ -2,6 +2,7 @@
 use crate::app::{ReaderApp, TtsAudioResultSlot};
 use eframe::egui;
 use egui::{Color32, CornerRadius, Stroke, Vec2};
+use reader_core::epub::ContentBlock;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -39,6 +40,25 @@ const VOLUME_OPTIONS: &[(i32, &str)] = &[
     (25, "+25%"),
     (50, "+50%"),
 ];
+
+fn page_for_block(ranges: &[(usize, usize)], block: usize, dual_column: bool) -> Option<usize> {
+    ranges
+        .iter()
+        .position(|(start, end)| *start <= block && block < *end)
+        .map(|page| if dual_column { page - page % 2 } else { page })
+}
+
+fn next_readable_block(blocks: &[ContentBlock], from: usize) -> usize {
+    blocks[from.min(blocks.len())..]
+        .iter()
+        .position(|block| {
+            matches!(
+                block,
+                ContentBlock::Paragraph { .. } | ContentBlock::Heading { .. }
+            )
+        })
+        .map_or(blocks.len(), |offset| from + offset)
+}
 
 impl ReaderApp {
     /// Render TTS as a horizontal bar between toolbar and content (Edge-style).
@@ -230,18 +250,29 @@ impl ReaderApp {
             "[TTS] start_playback: voice={}, rate={}, volume={}",
             self.tts_voice_name, self.tts_rate, self.tts_volume
         ));
+        let start_block = if self.scroll_mode {
+            self.current_block
+        } else {
+            self.page_block_ranges
+                .get(self.current_page)
+                .map(|(start, _)| *start)
+                .unwrap_or(self.current_block)
+        };
+        self.tts_start_from_block(self.current_chapter, start_block);
+    }
+
+    fn tts_start_from_block(&mut self, chapter: usize, block: usize) {
+        self.tts_cancel_audio();
         self.tts_stop_flag.store(false, Ordering::Relaxed);
         self.tts_playing = true;
         self.tts_paused = false;
-        self.tts_current_block = 0;
-        self.tts_prefetch_audio = None;
-        self.tts_prefetch_block = 0;
-        // Find first readable block
-        self.tts_current_block = self.tts_next_readable_block(0);
-        if let Some(total) = self.tts_block_count() {
+        self.tts_follow_view = true;
+        self.tts_current_chapter = chapter;
+        self.tts_current_block = self.tts_next_readable_block(chapter, block);
+        if let Some(total) = self.tts_block_count(chapter) {
             self.push_feedback_log(format!(
-                "[TTS] chapter has {} blocks, first readable={}",
-                total, self.tts_current_block
+                "[TTS] chapter {} has {} blocks, first readable={}",
+                chapter, total, self.tts_current_block
             ));
             if self.tts_current_block >= total {
                 self.push_feedback_log("[TTS] no readable blocks in chapter");
@@ -249,60 +280,73 @@ impl ReaderApp {
                 return;
             }
         }
+        self.tts_follow_current_position();
         self.tts_synthesize_current_block();
     }
 
     pub fn tts_stop_playback(&mut self) {
         self.push_feedback_log("[TTS] stop_playback");
-        self.tts_stop_flag.store(true, Ordering::Relaxed);
-        if let Some(sink) = self.tts_audio_sink.take() {
-            sink.stop();
-        }
+        self.tts_cancel_audio();
         self.tts_playing = false;
         self.tts_paused = false;
-        self.tts_pending_audio = None;
-        self.tts_prefetch_audio = None;
+        self.tts_follow_view = false;
         *self.tts_status.lock().unwrap() = String::new();
     }
 
-    /// Return the total number of blocks in the current chapter.
-    fn tts_block_count(&self) -> Option<usize> {
-        self.book.as_ref().and_then(|b| {
-            b.chapters
-                .get(self.current_chapter)
-                .map(|ch| ch.blocks.len())
-        })
+    fn tts_cancel_audio(&mut self) {
+        self.tts_stop_flag.store(true, Ordering::Relaxed);
+        self.tts_generation.fetch_add(1, Ordering::Relaxed);
+        if let Some(sink) = self.tts_audio_sink.take() {
+            sink.stop();
+        }
+        self.tts_pending_audio = None;
+        self.tts_prefetch_audio = None;
+    }
+
+    pub(crate) fn tts_detach_view(&mut self) {
+        if self.tts_playing && !self.tts_syncing_navigation {
+            self.tts_follow_view = false;
+            self.pending_restore_block = None;
+        }
+    }
+
+    /// Return the total number of blocks in a chapter.
+    fn tts_block_count(&self, chapter: usize) -> Option<usize> {
+        self.book
+            .as_ref()
+            .and_then(|b| b.chapters.get(chapter).map(|ch| ch.blocks.len()))
     }
 
     /// Starting from `from`, find the next block index that is a Paragraph or Heading.
-    fn tts_next_readable_block(&self, from: usize) -> usize {
-        let mut idx = from;
-        let total = self.tts_block_count().unwrap_or(0);
-        while idx < total {
-            if let Some(block) = self.book.as_ref().and_then(|b| {
-                b.chapters
-                    .get(self.current_chapter)
-                    .and_then(|ch| ch.blocks.get(idx))
-            }) {
-                if matches!(
-                    block,
-                    reader_core::epub::ContentBlock::Paragraph { .. }
-                        | reader_core::epub::ContentBlock::Heading { .. }
-                ) {
-                    return idx;
-                }
+    fn tts_next_readable_block(&self, chapter: usize, from: usize) -> usize {
+        self.book
+            .as_ref()
+            .and_then(|book| book.chapters.get(chapter))
+            .map_or(0, |chapter| next_readable_block(&chapter.blocks, from))
+    }
+
+    fn tts_next_readable_position(
+        &self,
+        mut chapter: usize,
+        mut from: usize,
+    ) -> Option<(usize, usize)> {
+        while chapter < self.total_chapters() {
+            let block = self.tts_next_readable_block(chapter, from);
+            if block < self.tts_block_count(chapter).unwrap_or(0) {
+                return Some((chapter, block));
             }
-            idx += 1;
+            chapter += 1;
+            from = 0;
         }
-        idx // past end
+        None
     }
 
     /// Get the text content of a block by index (empty string for non-text blocks).
-    fn tts_block_text(&self, block_idx: usize) -> String {
+    fn tts_block_text(&self, chapter: usize, block_idx: usize) -> String {
         self.book
             .as_ref()
             .and_then(|b| {
-                b.chapters.get(self.current_chapter).and_then(|ch| {
+                b.chapters.get(chapter).and_then(|ch| {
                     ch.blocks.get(block_idx).map(|block| match block {
                         reader_core::epub::ContentBlock::Paragraph { spans, .. } => {
                             spans.iter().map(|s| s.text.as_str()).collect::<String>()
@@ -317,21 +361,61 @@ impl ReaderApp {
             .unwrap_or_default()
     }
 
+    fn tts_navigate_to_chapter(&mut self, chapter: usize) {
+        self.tts_syncing_navigation = true;
+        while self.current_chapter < chapter {
+            self.next_chapter();
+        }
+        while self.current_chapter > chapter {
+            self.prev_chapter();
+        }
+        self.tts_syncing_navigation = false;
+    }
+
+    fn tts_follow_current_position(&mut self) {
+        if !self.tts_follow_view {
+            return;
+        }
+        if self.current_chapter != self.tts_current_chapter {
+            self.tts_navigate_to_chapter(self.tts_current_chapter);
+        }
+        if self.scroll_mode || self.pages_dirty {
+            self.pending_restore_block = Some(self.tts_current_block);
+            return;
+        }
+        let Some(page) = page_for_block(
+            &self.page_block_ranges,
+            self.tts_current_block,
+            self.is_dual_column,
+        ) else {
+            return;
+        };
+        if page != self.current_page {
+            let direction = if page > self.current_page { 1.0 } else { -1.0 };
+            self.tts_syncing_navigation = true;
+            self.trigger_page_animation_to(page, direction);
+            self.tts_syncing_navigation = false;
+        }
+    }
+
     fn tts_advance_to_next_block(&mut self) {
-        let total = self.tts_block_count().unwrap_or(0);
-        let next = self.tts_next_readable_block(self.tts_current_block + 1);
-        if next >= total {
-            // Chapter finished
-            self.push_feedback_log("[TTS] chapter finished");
+        let Some((chapter, block)) =
+            self.tts_next_readable_position(self.tts_current_chapter, self.tts_current_block + 1)
+        else {
+            self.push_feedback_log("[TTS] book finished");
             self.tts_stop_playback();
             *self.tts_status.lock().unwrap() = self.i18n.t("tts.chapter_done").to_string();
             return;
-        }
-        self.tts_current_block = next;
+        };
+        self.tts_current_chapter = chapter;
+        self.tts_current_block = block;
+        self.tts_follow_current_position();
 
         // Check if we have prefetched audio for this block
         if let Some(prefetch) = self.tts_prefetch_audio.take() {
-            if self.tts_prefetch_block == self.tts_current_block {
+            if self.tts_prefetch_chapter == self.tts_current_chapter
+                && self.tts_prefetch_block == self.tts_current_block
+            {
                 let data = prefetch.lock().unwrap().take();
                 match data {
                     Some(Ok(bytes)) => {
@@ -369,7 +453,7 @@ impl ReaderApp {
             sink.stop();
         }
 
-        let text = self.tts_block_text(self.tts_current_block);
+        let text = self.tts_block_text(self.tts_current_chapter, self.tts_current_block);
         if text.trim().is_empty() {
             self.tts_advance_to_next_block();
             return;
@@ -384,18 +468,19 @@ impl ReaderApp {
 
     /// Start prefetching audio for the next readable block after current.
     fn tts_start_prefetch(&mut self) {
-        let total = self.tts_block_count().unwrap_or(0);
-        let next = self.tts_next_readable_block(self.tts_current_block + 1);
-        if next >= total {
+        let Some((chapter, block)) =
+            self.tts_next_readable_position(self.tts_current_chapter, self.tts_current_block + 1)
+        else {
             self.tts_prefetch_audio = None;
             return;
-        }
-        let text = self.tts_block_text(next);
+        };
+        let text = self.tts_block_text(chapter, block);
         if text.trim().is_empty() {
             self.tts_prefetch_audio = None;
             return;
         }
-        self.tts_prefetch_block = next;
+        self.tts_prefetch_chapter = chapter;
+        self.tts_prefetch_block = block;
         let prefetch = self.tts_spawn_synthesis(text);
         self.tts_prefetch_audio = Some(prefetch);
 
@@ -409,6 +494,8 @@ impl ReaderApp {
         let rate = self.tts_rate;
         let volume = self.tts_volume;
         let stop_flag = self.tts_stop_flag.clone();
+        let generation = self.tts_generation.load(Ordering::Relaxed);
+        let current_generation = self.tts_generation.clone();
         let status = self.tts_status.clone();
         let ctx = self.last_egui_ctx.clone();
         let logs = self.feedback_logs.clone();
@@ -426,7 +513,9 @@ impl ReaderApp {
         );
 
         std::thread::spawn(move || {
-            if stop_flag.load(Ordering::Relaxed) {
+            if stop_flag.load(Ordering::Relaxed)
+                || current_generation.load(Ordering::Relaxed) != generation
+            {
                 return;
             }
             let t0 = std::time::Instant::now();
@@ -457,6 +546,12 @@ impl ReaderApp {
                 let audio = tts.synthesize(&text, &config)?;
                 Ok(audio.audio_bytes)
             })();
+
+            if stop_flag.load(Ordering::Relaxed)
+                || current_generation.load(Ordering::Relaxed) != generation
+            {
+                return;
+            }
 
             match result {
                 Ok(bytes) => {
@@ -534,9 +629,40 @@ impl ReaderApp {
         let cursor = std::io::Cursor::new(bytes.to_vec());
         let source = rodio::Decoder::new(cursor)?;
         sink.append(source);
+        if self.tts_paused {
+            sink.pause();
+        }
         let sink = Arc::new(sink);
         self.tts_audio_sink = Some(sink);
         *self.tts_status.lock().unwrap() = self.i18n.t("tts.playing").to_string();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{next_readable_block, page_for_block};
+    use reader_core::epub::ContentBlock;
+
+    #[test]
+    fn maps_blocks_to_single_and_dual_pages() {
+        let ranges = [(0, 3), (3, 6), (6, 9), (9, 12)];
+        assert_eq!(page_for_block(&ranges, 7, false), Some(2));
+        assert_eq!(page_for_block(&ranges, 10, true), Some(2));
+        assert_eq!(page_for_block(&ranges, 12, false), None);
+    }
+
+    #[test]
+    fn skips_non_text_blocks() {
+        let blocks = [
+            ContentBlock::BlankLine,
+            ContentBlock::Separator,
+            ContentBlock::Paragraph {
+                spans: Vec::new(),
+                anchor_id: None,
+            },
+        ];
+        assert_eq!(next_readable_block(&blocks, 0), 2);
+        assert_eq!(next_readable_block(&blocks, 3), 3);
     }
 }


### PR DESCRIPTION
## 变更

- TTS 按段落连续朗读，并在章节结束后继续下一章。
- 页面默认跟随当前朗读位置；手动翻页、换章或滚动后只取消视图跟随，不打断 TTS。
- 正文右键增加“从此处开始朗读”和“跟随阅读”。

原实现只按当前 UI 章节和 block 读取内容，预取也没有章节标识，导致导航后音频错位，且章末会直接停止。

## 验证

- `cargo test -p rust_epub_reader`：15 passed
- `cargo build -p rust_epub_reader`：Linux 编译通过
