### PR TITLE
[BUG] 修复: TTS 全书完成状态文案

### DIFF
--- a/core/src/i18n/en.json
+++ b/core/src/i18n/en.json
@@ -262,6 +262,7 @@
   "tts.paused": "Paused",
   "tts.ready": "Ready to play",
   "tts.chapter_done": "Chapter finished",
+  "tts.book_done": "Book finished",
   "tts.rate_normal": "Normal",
   "toolbar.tts": "🔊 TTS",
   "toolbar.api_settings": "⚙ API Settings",

--- a/core/src/i18n/zh_cn.json
+++ b/core/src/i18n/zh_cn.json
@@ -262,6 +262,7 @@
   "tts.paused": "已暂停",
   "tts.ready": "等待播放",
   "tts.chapter_done": "本章朗读完毕",
+  "tts.book_done": "全书朗读完毕",
   "tts.rate_normal": "正常",
   "toolbar.tts": "🔊 朗读",
   "toolbar.api_settings": "⚙ API设置",

--- a/desktop/src/ui/tts.rs
+++ b/desktop/src/ui/tts.rs
@@ -425,7 +425,7 @@ impl ReaderApp {
         else {
             self.push_feedback_log("[TTS] book finished");
             self.tts_stop_playback();
-            *self.tts_status.lock().unwrap() = self.i18n.t("tts.chapter_done").to_string();
+            *self.tts_status.lock().unwrap() = self.i18n.t("tts.book_done").to_string();
             return;
         };
         self.tts_current_chapter = chapter;


### PR DESCRIPTION
## 分类

- [x] BUG 修复（bug）

## 变更内容概述

修复 TTS 播放完整本书后仍显示“本章朗读完毕”的问题，新增并使用“全书朗读完毕”状态文案；保留单章完成文案供后续场景使用。

## 相关 Issue（可选）

- 关联 PR #41 的后续修复

## 影响平台

- [x] Desktop (Windows / macOS / Linux)
- [x] Core / EPUB 解析 / 搜索 / 分享

## 验证方式

- [x] 已运行 `cargo fmt --all -- --check`
- [x] 已运行 `cargo check -p rust_epub_reader --all-targets`
- [x] 已运行 `cargo test -p rust_epub_reader`（18 项通过）
- [x] 已运行 `git diff --check`

## 兼容性/风险评估

- [x] 无破坏性变更
- [x] 无配置、依赖或本地数据结构变更
