### PR TITLE
[Feature] 新功能: 连续章节滚动阅读 v2

### DIFF
--- a/android/app/src/main/java/com/epub/reader/ui/reader/ReaderScreen.kt
+++ b/android/app/src/main/java/com/epub/reader/ui/reader/ReaderScreen.kt
@@ -802,6 +802,13 @@ fun ReaderScreen(
             ) {
                 ScrollModeContent(
                     chapter = chapter,
+                    allChapters = book.chapters,
+                    initialChapter = currentChapter,
+                    onChapterVisible = { visibleChapter ->
+                        if (visibleChapter != currentChapter) {
+                            onChapterChange(visibleChapter)
+                        }
+                    },
                     fontSize = fontSize,
                     textColor = textColor,
                     linkColor = linkColor,

--- a/android/app/src/main/java/com/epub/reader/ui/reader/ScrollModeContent.kt
+++ b/android/app/src/main/java/com/epub/reader/ui/reader/ScrollModeContent.kt
@@ -28,6 +28,9 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 @Composable
 internal fun ScrollModeContent(
     chapter: Chapter,
+    allChapters: List<Chapter> = listOf(chapter),
+    initialChapter: Int = 0,
+    onChapterVisible: (Int) -> Unit = {},
     fontSize: Float,
     textColor: Color,
     linkColor: Color,
@@ -51,9 +54,7 @@ internal fun ScrollModeContent(
     ,initialBlock: Int = 0
     ,onPositionChange: (Int) -> Unit = {}
 ) {
-    val showChapterTitle = remember(chapter) { shouldRenderChapterTitle(chapter) }
-    val titleOffset = if (showChapterTitle) 1 else 0
-    val listState = rememberLazyListState(initialFirstVisibleItemIndex = initialBlock.coerceAtLeast(0) + titleOffset)
+    val listState = rememberLazyListState()
     val configuration = LocalConfiguration.current
     val scrollDensity = LocalDensity.current
     val hPaddingDp = configuration.screenWidthDp.dp * 0.065f
@@ -67,18 +68,26 @@ internal fun ScrollModeContent(
     var pullTriggered by remember { mutableStateOf(false) }
     val pullThreshold = with(scrollDensity) { 120.dp.toPx() }
 
-    LaunchedEffect(chapter, showChapterTitle) {
-        listState.scrollToItem(initialBlock.coerceIn(0, chapter.blocks.lastIndex.coerceAtLeast(0)) + titleOffset)
+    LaunchedEffect(allChapters, initialChapter) {
+        listState.scrollToItem(initialChapter.coerceIn(0, allChapters.lastIndex.coerceAtLeast(0)))
     }
 
-    LaunchedEffect(chapter, showChapterTitle) {
+    LaunchedEffect(listState) {
+        snapshotFlow { listState.layoutInfo.visibleItemsInfo.firstOrNull()?.index }
+            .distinctUntilChanged()
+            .collect { chapterIndex ->
+                chapterIndex?.let(onChapterVisible)
+            }
+    }
+
+    LaunchedEffect(allChapters, initialChapter) {
         snapshotFlow { listState.firstVisibleItemIndex }
             .distinctUntilChanged()
-            .collect { itemIndex ->
+            .collect { chapterIndex ->
                 delay(350)
-                val block = (itemIndex - titleOffset)
-                    .coerceIn(0, chapter.blocks.lastIndex.coerceAtLeast(0))
-                onPositionChange(block)
+                if (chapterIndex == initialChapter) {
+                    onPositionChange(initialBlock.coerceIn(0, chapter.blocks.lastIndex.coerceAtLeast(0)))
+                }
             }
     }
 
@@ -130,54 +139,55 @@ internal fun ScrollModeContent(
             .nestedScroll(nestedScrollConnection),
         contentPadding = PaddingValues(start = hPaddingDp, end = hPaddingDp, top = topPaddingDp, bottom = bottomPaddingDp)
     ) {
-        if (showChapterTitle) {
-            // 章节标题
-            item {
-                Text(
-                    text = breakTitleIntoLines(chapter.title, scrollContentWidthPx, fontSize * titleFontScale, scrollSpToPx),
-                    style = TextStyle(
-                        fontSize = (fontSize * titleFontScale).sp,
-                        lineHeight = (fontSize * titleFontScale * 1.45f).sp,
-                        fontWeight = FontWeight.Bold,
+        itemsIndexed(allChapters, key = { index, _ -> "chapter-$index" }) { chapterIndex, chapterItem ->
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = if (chapterIndex == 0) 0.dp else topPaddingDp)
+            ) {
+                if (shouldRenderChapterTitle(chapterItem)) {
+                    Text(
+                        text = breakTitleIntoLines(chapterItem.title, scrollContentWidthPx, fontSize * titleFontScale, scrollSpToPx),
+                        style = TextStyle(
+                            fontSize = (fontSize * titleFontScale).sp,
+                            lineHeight = (fontSize * titleFontScale * 1.45f).sp,
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = fontFamily,
+                            color = textColor,
+                            textAlign = TextAlign.Center
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = topPaddingDp * 0.5f, bottom = topPaddingDp * 2.0f)
+                    )
+                }
+                chapterItem.blocks.forEachIndexed { blockIndex, block ->
+                    ContentBlockView(
+                        blockIndex = blockIndex,
+                        block = block,
+                        fontSize = fontSize,
+                        textColor = textColor,
+                        linkColor = linkColor,
+                        bgColor = bgColor,
                         fontFamily = fontFamily,
-                        color = textColor,
-                        textAlign = TextAlign.Center
-                    ),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = topPaddingDp * 0.5f, bottom = topPaddingDp * 2.0f)
-                )
+                        onLinkClick = onLinkClick,
+                        onTextTapped = onTextTapped,
+                        lineSpacing = lineSpacing,
+                        paraSpacing = paraSpacing,
+                        textIndentChars = textIndent,
+                        titleFontScale = titleFontScale,
+                        textSelection = textSelection,
+                        onSelectionChange = onSelectionChange,
+                        blockLayoutRegistry = if (chapterIndex == initialChapter) blockLayoutRegistry else null,
+                        highlights = if (chapterIndex == initialChapter) highlights else emptyList(),
+                        cscBlockCorrections = if (chapterIndex == initialChapter) cscBlockCorrections[blockIndex] ?: emptyList() else emptyList(),
+                        cscMode = cscMode,
+                        ttsCurrentBlock = if (chapterIndex == initialChapter) ttsCurrentBlock else -1,
+                        onCscCorrectionClick = onCscCorrectionClick
+                    )
+                }
+                Spacer(Modifier.height(64.dp))
             }
         }
-
-        // 内容块
-        itemsIndexed(chapter.blocks) { blockIndex, block ->
-            ContentBlockView(
-                blockIndex = blockIndex,
-                block = block,
-                fontSize = fontSize,
-                textColor = textColor,
-                linkColor = linkColor,
-                bgColor = bgColor,
-                fontFamily = fontFamily,
-                onLinkClick = onLinkClick,
-                onTextTapped = onTextTapped,
-                lineSpacing = lineSpacing,
-                paraSpacing = paraSpacing,
-                textIndentChars = textIndent,
-                titleFontScale = titleFontScale,
-                textSelection = textSelection,
-                onSelectionChange = onSelectionChange,
-                blockLayoutRegistry = blockLayoutRegistry,
-                highlights = highlights,
-                cscBlockCorrections = cscBlockCorrections[blockIndex] ?: emptyList(),
-                cscMode = cscMode,
-                ttsCurrentBlock = ttsCurrentBlock,
-                onCscCorrectionClick = onCscCorrectionClick
-            )
-        }
-
-        // 底部留白
-        item { Spacer(Modifier.height(64.dp)) }
     }
 }

--- a/android/app/src/main/java/com/epub/reader/ui/reader/ScrollModeContent.kt
+++ b/android/app/src/main/java/com/epub/reader/ui/reader/ScrollModeContent.kt
@@ -55,6 +55,8 @@ internal fun ScrollModeContent(
     ,onPositionChange: (Int) -> Unit = {}
 ) {
     val listState = rememberLazyListState()
+    var suppressChapterCallback by remember { mutableStateOf(false) }
+    var lastVisibleChapter by remember { mutableIntStateOf(initialChapter) }
     val configuration = LocalConfiguration.current
     val scrollDensity = LocalDensity.current
     val hPaddingDp = configuration.screenWidthDp.dp * 0.065f
@@ -68,15 +70,34 @@ internal fun ScrollModeContent(
     var pullTriggered by remember { mutableStateOf(false) }
     val pullThreshold = with(scrollDensity) { 120.dp.toPx() }
 
-    LaunchedEffect(allChapters, initialChapter) {
+    LaunchedEffect(allChapters) {
+        suppressChapterCallback = true
         listState.scrollToItem(initialChapter.coerceIn(0, allChapters.lastIndex.coerceAtLeast(0)))
+        // Let the programmatic positioning settle before user-driven chapter
+        // visibility changes are reported to the parent.
+        withFrameNanos { }
+        suppressChapterCallback = false
+    }
+
+    LaunchedEffect(initialChapter) {
+        if (initialChapter == lastVisibleChapter) return@LaunchedEffect
+        suppressChapterCallback = true
+        listState.scrollToItem(initialChapter.coerceIn(0, allChapters.lastIndex.coerceAtLeast(0)))
+        lastVisibleChapter = initialChapter
+        withFrameNanos { }
+        suppressChapterCallback = false
     }
 
     LaunchedEffect(listState) {
         snapshotFlow { listState.layoutInfo.visibleItemsInfo.firstOrNull()?.index }
             .distinctUntilChanged()
             .collect { chapterIndex ->
-                chapterIndex?.let(onChapterVisible)
+                if (!suppressChapterCallback) {
+                    chapterIndex?.let {
+                        lastVisibleChapter = it
+                        onChapterVisible(it)
+                    }
+                }
             }
     }
 

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -17,6 +17,8 @@ use reader_core::i18n::{I18n, Language};
 use reader_core::library::Library;
 use reader_core::sharing::{start_listener, DiscoveredPeer, PeerStore};
 
+use crate::ui::reader_state::ContinuousScrollState;
+
 type FontDiscoveryResult = Arc<Mutex<Option<(Vec<String>, HashMap<String, String>)>>>;
 pub(crate) type TtsAudioResultSlot = Arc<Mutex<Option<Result<Vec<u8>, String>>>>;
 
@@ -521,6 +523,7 @@ pub struct ReaderApp {
     pub view: AppView,
     pub library: Library,
     pub scroll_mode: bool,
+    pub(crate) continuous_scroll: ContinuousScrollState,
     pub current_page: usize,
     pub total_pages: usize,
     pub page_block_ranges: Vec<(usize, usize)>,
@@ -728,6 +731,7 @@ pub enum UpdateState {
 
 #[derive(Clone)]
 pub struct CrossChapterSnapshot {
+    pub chapter: usize,
     pub blocks: Arc<Vec<reader_core::epub::ContentBlock>>,
     pub block_ranges: Vec<(usize, usize)>,
     pub total_pages: usize,
@@ -825,6 +829,7 @@ impl Default for ReaderApp {
             view: AppView::Library,
             library,
             scroll_mode: false,
+            continuous_scroll: ContinuousScrollState::default(),
             current_page: 0,
             total_pages: 0,
             page_block_ranges: Vec::new(),
@@ -1477,6 +1482,7 @@ impl ReaderApp {
         if let Some(book) = &self.book {
             if let Some(ch) = book.chapters.get(self.current_chapter) {
                 self.page_anim_cross_chapter_snapshot = Some(CrossChapterSnapshot {
+                    chapter: self.current_chapter,
                     blocks: Arc::new(ch.blocks.clone()),
                     block_ranges: self.page_block_ranges.clone(),
                     total_pages: self.total_pages,
@@ -1509,8 +1515,9 @@ impl ReaderApp {
         }
     }
 
-    pub fn schedule_position_save(&mut self, block: usize) {
-        if self.current_block != block {
+    pub fn schedule_position_save(&mut self, chapter: usize, block: usize) {
+        if self.current_chapter != chapter || self.current_block != block {
+            self.current_chapter = chapter;
             self.current_block = block;
             self.position_save_due =
                 Some(std::time::Instant::now() + std::time::Duration::from_millis(400));

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -255,6 +255,11 @@ impl ReaderApp {
                 {
                     self.continuous_scroll.reset(self.current_chapter, total_ch);
                 }
+                if self.continuous_scroll.near_end()
+                    && self.continuous_scroll.append_next(total_ch).is_some()
+                {
+                    ui.ctx().request_repaint();
+                }
                 let loaded_end = self.continuous_scroll.loaded_end;
                 let start_chapter = self.continuous_scroll.start_chapter;
                 let continuous_chapters: Vec<(String, Vec<ContentBlock>)> = self

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -297,6 +297,9 @@ impl ReaderApp {
                 if ui.rect_contains_pointer(ui.available_rect_before_wrap())
                     && ui.input(|i| i.raw_scroll_delta.y != 0.0)
                 {
+                    let scroll_delta_y = ui.input(|i| i.raw_scroll_delta.y);
+                    self.continuous_scroll
+                        .allow_prepend_after_user_scroll(scroll_delta_y);
                     self.tts_detach_view();
                 }
                 let mut scroll_area = egui::ScrollArea::vertical().auto_shrink([false; 2]);

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -255,16 +255,6 @@ impl ReaderApp {
                 {
                     self.continuous_scroll.reset(self.current_chapter, total_ch);
                 }
-                if self.continuous_scroll.near_end()
-                    && self.continuous_scroll.append_next(total_ch).is_some()
-                {
-                    ui.ctx().request_repaint();
-                }
-                if self.continuous_scroll.near_start()
-                    && self.continuous_scroll.prepend_previous().is_some()
-                {
-                    ui.ctx().request_repaint();
-                }
                 let loaded_end = self.continuous_scroll.loaded_end;
                 let start_chapter = self.continuous_scroll.start_chapter;
                 let scroll_adjustment = self.continuous_scroll.take_scroll_adjustment();
@@ -410,14 +400,15 @@ impl ReaderApp {
                     self.continuous_scroll.set_visible_chapter(chapter);
                     self.schedule_position_save(chapter, block);
                 }
-                if scroll_output.content_size.y - scroll_output.state.offset.y
-                    < scroll_output.inner_rect.height().max(600.0)
-                    && self.continuous_scroll.append_next(total_ch).is_some()
-                {
-                    ui.ctx().request_repaint();
-                }
-                self.continuous_scroll.trim_window();
-                if self.continuous_scroll.start_chapter != start_chapter {
+                let near_start = self.continuous_scroll.near_start();
+                let near_end = self.continuous_scroll.near_end();
+                if near_start {
+                    if self.continuous_scroll.prepend_previous().is_some() {
+                        self.continuous_scroll.trim_bottom();
+                        ui.ctx().request_repaint();
+                    }
+                } else if near_end && self.continuous_scroll.append_next(total_ch).is_some() {
+                    self.continuous_scroll.trim_window();
                     ui.ctx().request_repaint();
                 }
             } else {

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -8,8 +8,12 @@ use egui::{Color32, FontId, UiBuilder};
 
 use crate::app::{ReaderApp, TextSelection};
 use reader_core::epub::ContentBlock;
+use reader_core::library::HighlightColor;
 
 use super::{reader_block::*, reader_state::*};
+
+type BlockHighlightRanges = HashMap<usize, Vec<(usize, usize, HighlightColor)>>;
+type ChapterHighlightRanges = HashMap<usize, BlockHighlightRanges>;
 
 impl ReaderApp {
     pub fn recalculate_pages(&mut self, available_height: f32, max_width: f32) {
@@ -263,17 +267,11 @@ impl ReaderApp {
                             .collect()
                     })
                     .unwrap_or_default();
-                let loaded_highlights = self
+                let loaded_highlights: ChapterHighlightRanges = self
                     .book_config
                     .as_ref()
                     .map(|cfg| {
-                        let mut by_chapter: HashMap<
-                            usize,
-                            HashMap<
-                                usize,
-                                Vec<(usize, usize, reader_core::library::HighlightColor)>,
-                            >,
-                        > = HashMap::new();
+                        let mut by_chapter = ChapterHighlightRanges::new();
                         for highlight in cfg.highlights.iter().filter(|highlight| {
                             highlight.chapter >= start_chapter && highlight.chapter < loaded_end
                         }) {

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -1,4 +1,6 @@
 //! The main reading interface, integrating text layout and UI overlays.
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use eframe::egui;
@@ -92,7 +94,10 @@ impl ReaderApp {
         // Set TTS read-along highlight block
         if self.tts_playing && !self.tts_paused && self.current_chapter == self.tts_current_chapter
         {
-            TTS_HIGHLIGHT_BLOCK.set(Some(self.tts_current_block));
+            TTS_HIGHLIGHT_BLOCK.set(Some(BlockKey::new(
+                self.tts_current_chapter,
+                self.tts_current_block,
+            )));
         } else {
             TTS_HIGHLIGHT_BLOCK.set(None);
         }
@@ -103,8 +108,12 @@ impl ReaderApp {
             map.clear();
             if self.csc_mode != reader_core::csc::CorrectionMode::None {
                 for ((ch, block_idx), corrs) in &self.csc_cache {
-                    if *ch == self.current_chapter {
-                        map.insert(*block_idx, corrs.clone());
+                    if (!self.scroll_mode && *ch == self.current_chapter)
+                        || (self.scroll_mode
+                            && *ch >= self.continuous_scroll.start_chapter
+                            && *ch < self.continuous_scroll.loaded_end)
+                    {
+                        map.insert(BlockKey::new(*ch, *block_idx), corrs.clone());
                     }
                 }
             }
@@ -149,467 +158,313 @@ impl ReaderApp {
         let has_previous_chapter = self.previous_chapter.is_some();
         let mut is_dual_column = false;
 
-        if let Some(book) = &self.book {
-            if let Some(chapter) = book.chapters.get(self.current_chapter) {
-                let available_width = ui.available_width();
-                let available_height = ui.available_height();
-                if (self.last_avail_width - available_width).abs() > 1.0
-                    || (self.last_avail_height - available_height).abs() > 1.0
-                {
-                    self.pages_dirty = true;
-                    self.last_avail_width = available_width;
-                    self.last_avail_height = available_height;
-                }
-                let layout =
-                    reader_text_layout(available_width, available_height, self.scroll_mode);
-                let dual_column = layout.is_dual_column;
-                is_dual_column = dual_column;
-                self.is_dual_column = dual_column;
-                let text_width = layout.text_width;
-                let h_margin = layout.h_margin;
-                let title = chapter.title.clone();
-                let blocks = chapter.blocks.clone();
-                let total_ch = book.chapters.len();
-                if !self.scroll_mode && self.pages_dirty {
-                    self.recalculate_pages(ui.available_height(), text_width);
-                }
-                if !self.scroll_mode
-                    && self.total_pages > 0
-                    && self.current_page >= self.total_pages
-                {
-                    self.current_page = self.total_pages - 1;
-                }
-                if dual_column && !self.current_page.is_multiple_of(2) {
-                    self.current_page = self.current_page.saturating_sub(1);
-                }
-                let (block_start, block_end) = if self.scroll_mode {
-                    (0, blocks.len())
-                } else if let Some(&(s, e)) = self.page_block_ranges.get(self.current_page) {
-                    (s.min(blocks.len()), e.min(blocks.len()))
-                } else {
-                    (0, blocks.len())
-                };
-                let show_title = self.scroll_mode || self.current_page == 0;
+        let current_chapter_data = self.book.as_ref().and_then(|book| {
+            book.chapters.get(self.current_chapter).map(|chapter| {
+                (
+                    chapter.title.clone(),
+                    chapter.blocks.clone(),
+                    book.chapters.len(),
+                )
+            })
+        });
+        if let Some((title, blocks, total_ch)) = current_chapter_data {
+            let available_width = ui.available_width();
+            let available_height = ui.available_height();
+            if (self.last_avail_width - available_width).abs() > 1.0
+                || (self.last_avail_height - available_height).abs() > 1.0
+            {
+                self.pages_dirty = true;
+                self.last_avail_width = available_width;
+                self.last_avail_height = available_height;
+            }
+            let layout = reader_text_layout(available_width, available_height, self.scroll_mode);
+            let dual_column = layout.is_dual_column;
+            is_dual_column = dual_column;
+            self.is_dual_column = dual_column;
+            let text_width = layout.text_width;
+            let h_margin = layout.h_margin;
+            if !self.scroll_mode && self.pages_dirty {
+                self.recalculate_pages(ui.available_height(), text_width);
+            }
+            if !self.scroll_mode && self.total_pages > 0 && self.current_page >= self.total_pages {
+                self.current_page = self.total_pages - 1;
+            }
+            if dual_column && !self.current_page.is_multiple_of(2) {
+                self.current_page = self.current_page.saturating_sub(1);
+            }
+            let (block_start, block_end) = if self.scroll_mode {
+                (0, blocks.len())
+            } else if let Some(&(s, e)) = self.page_block_ranges.get(self.current_page) {
+                (s.min(blocks.len()), e.min(blocks.len()))
+            } else {
+                (0, blocks.len())
+            };
+            let show_title = self.scroll_mode || self.current_page == 0;
 
-                // Build per-block highlight ranges for the current chapter
-                // Each block can have multiple highlight ranges with different colors
-                let highlight_ranges: std::collections::HashMap<
-                    usize,
-                    Vec<(usize, usize, reader_core::library::HighlightColor)>,
-                > = self
+            // Build per-block highlight ranges for the current chapter
+            // Each block can have multiple highlight ranges with different colors
+            let highlight_ranges: std::collections::HashMap<
+                usize,
+                Vec<(usize, usize, reader_core::library::HighlightColor)>,
+            > = self
+                .book_config
+                .as_ref()
+                .map(|cfg| {
+                    let mut map: std::collections::HashMap<
+                        usize,
+                        Vec<(usize, usize, reader_core::library::HighlightColor)>,
+                    > = std::collections::HashMap::new();
+                    for h in cfg
+                        .highlights
+                        .iter()
+                        .filter(|h| h.chapter == self.current_chapter)
+                    {
+                        // Only single-block highlights supported for now
+                        map.entry(h.start_block).or_default().push((
+                            h.start_offset,
+                            h.end_offset,
+                            h.color.clone(),
+                        ));
+                    }
+                    map
+                })
+                .unwrap_or_default();
+
+            if self.scroll_mode {
+                let mut layout_hasher = std::collections::hash_map::DefaultHasher::new();
+                text_width.to_bits().hash(&mut layout_hasher);
+                self.font_size.to_bits().hash(&mut layout_hasher);
+                self.line_spacing.to_bits().hash(&mut layout_hasher);
+                self.para_spacing.to_bits().hash(&mut layout_hasher);
+                self.text_indent.hash(&mut layout_hasher);
+                self.reader_font_family.hash(&mut layout_hasher);
+                self.reader_cjk_font_family.hash(&mut layout_hasher);
+                if self
+                    .continuous_scroll
+                    .update_layout_signature(layout_hasher.finish())
+                {
+                    self.scroll_to_top = true;
+                }
+                if self
+                    .continuous_scroll
+                    .needs_reset(self.current_chapter, total_ch)
+                {
+                    self.continuous_scroll.reset(self.current_chapter, total_ch);
+                }
+                let loaded_end = self.continuous_scroll.loaded_end;
+                let start_chapter = self.continuous_scroll.start_chapter;
+                let continuous_chapters: Vec<(String, Vec<ContentBlock>)> = self
+                    .book
+                    .as_ref()
+                    .map(|book| {
+                        book.chapters[start_chapter..loaded_end]
+                            .iter()
+                            .map(|chapter| (chapter.title.clone(), chapter.blocks.clone()))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                let loaded_highlights = self
                     .book_config
                     .as_ref()
                     .map(|cfg| {
-                        let mut map: std::collections::HashMap<
+                        let mut by_chapter: HashMap<
                             usize,
-                            Vec<(usize, usize, reader_core::library::HighlightColor)>,
-                        > = std::collections::HashMap::new();
-                        for h in cfg
-                            .highlights
-                            .iter()
-                            .filter(|h| h.chapter == self.current_chapter)
-                        {
-                            // Only single-block highlights supported for now
-                            map.entry(h.start_block).or_default().push((
-                                h.start_offset,
-                                h.end_offset,
-                                h.color.clone(),
-                            ));
+                            HashMap<
+                                usize,
+                                Vec<(usize, usize, reader_core::library::HighlightColor)>,
+                            >,
+                        > = HashMap::new();
+                        for highlight in cfg.highlights.iter().filter(|highlight| {
+                            highlight.chapter >= start_chapter && highlight.chapter < loaded_end
+                        }) {
+                            by_chapter
+                                .entry(highlight.chapter)
+                                .or_default()
+                                .entry(highlight.start_block)
+                                .or_default()
+                                .push((
+                                    highlight.start_offset,
+                                    highlight.end_offset,
+                                    highlight.color.clone(),
+                                ));
                         }
-                        map
+                        by_chapter
                     })
                     .unwrap_or_default();
-
-                if self.scroll_mode {
-                    if ui.rect_contains_pointer(ui.available_rect_before_wrap())
-                        && ui.input(|i| i.raw_scroll_delta.y != 0.0)
+                let empty_highlights: HashMap<
+                    usize,
+                    Vec<(usize, usize, reader_core::library::HighlightColor)>,
+                > = HashMap::new();
+                if ui.rect_contains_pointer(ui.available_rect_before_wrap())
+                    && ui.input(|i| i.raw_scroll_delta.y != 0.0)
+                {
+                    self.tts_detach_view();
+                }
+                let mut scroll_area = egui::ScrollArea::vertical().auto_shrink([false; 2]);
+                if self.scroll_to_top {
+                    scroll_area = scroll_area.vertical_scroll_offset(0.0);
+                    self.scroll_to_top = false;
+                }
+                let scroll_output = scroll_area.show(ui, |ui| {
+                    for (offset, (chapter_title, chapter_blocks)) in
+                        continuous_chapters.iter().enumerate()
                     {
-                        self.tts_detach_view();
-                    }
-                    let mut scroll_area = egui::ScrollArea::vertical().auto_shrink([false; 2]);
-                    if self.scroll_to_top {
-                        scroll_area = scroll_area.vertical_scroll_offset(0.0);
-                        self.scroll_to_top = false;
-                    }
-                    let scroll_output = scroll_area.show(ui, |ui| {
+                        let chapter_idx = start_chapter + offset;
+                        let chapter_ranges = loaded_highlights.get(&chapter_idx).unwrap_or(
+                            if chapter_idx == self.current_chapter {
+                                &highlight_ranges
+                            } else {
+                                &empty_highlights
+                            },
+                        );
                         render_content_layout(
                             ui,
                             h_margin,
                             text_width,
-                            &title,
-                            &blocks,
-                            block_start,
-                            block_end,
-                            show_title,
+                            chapter_title,
+                            chapter_blocks,
+                            0,
+                            chapter_blocks.len(),
+                            true,
                             self.font_size,
                             self.title_font_scale,
                             self.reader_bg_color,
-                            self.current_chapter,
+                            chapter_idx,
                             total_ch,
                             &mut action_prev_chapter,
                             &mut action_next_chapter,
                             &mut action_go_back,
-                            true,
+                            chapter_idx + 1 == total_ch,
                             has_previous_chapter,
                             self.reader_font_color,
                             &effective_font_family,
                             &self.i18n,
                             &mut clicked_link,
-                            &highlight_ranges,
+                            chapter_ranges,
                         );
-                        if let Some(target) = self.pending_restore_block {
-                            BLOCK_GALLEYS.with(|galleys| {
-                                if let Some((_, _, rect, _, _)) = galleys
-                                    .borrow()
-                                    .iter()
-                                    .find(|(idx, _, _, _, _)| *idx == target)
-                                {
-                                    if !rect.intersects(ui.clip_rect()) {
-                                        ui.scroll_to_rect(*rect, Some(egui::Align::Min));
-                                    }
-                                    self.pending_restore_block = None;
+                    }
+                    if let Some(target) = self.pending_restore_block {
+                        BLOCK_GALLEYS.with(|galleys| {
+                            if let Some(entry) = galleys.borrow().iter().find(|entry| {
+                                entry.key.chapter == self.current_chapter
+                                    && entry.key.block == target
+                            }) {
+                                if !entry.rect.intersects(ui.clip_rect()) {
+                                    ui.scroll_to_rect(entry.rect, Some(egui::Align::Min));
                                 }
-                            });
+                                self.pending_restore_block = None;
+                            }
+                        });
+                    }
+                });
+                let viewport = scroll_output.inner_rect;
+                self.continuous_scroll.record_scroll_output(
+                    scroll_output.state.offset.y,
+                    scroll_output.content_size.y,
+                    viewport.height(),
+                );
+                for chapter_idx in start_chapter..loaded_end {
+                    let height = BLOCK_GALLEYS.with(|galleys| {
+                        let entries = galleys.borrow();
+                        let mut min_y = f32::INFINITY;
+                        let mut max_y = f32::NEG_INFINITY;
+                        for entry in entries
+                            .iter()
+                            .filter(|entry| entry.key.chapter == chapter_idx)
+                        {
+                            min_y = min_y.min(entry.rect.min.y);
+                            max_y = max_y.max(entry.rect.max.y);
+                        }
+                        if min_y.is_finite() && max_y.is_finite() {
+                            Some(max_y - min_y)
+                        } else {
+                            None
                         }
                     });
-                    let viewport = scroll_output.inner_rect;
-                    let visible_block = BLOCK_GALLEYS.with(|galleys| {
-                        galleys
-                            .borrow()
-                            .iter()
-                            .filter(|(_, _, rect, _, _)| rect.intersects(viewport))
-                            .min_by(|a, b| a.2.top().total_cmp(&b.2.top()))
-                            .map(|(idx, _, _, _, _)| *idx)
-                    });
-                    if let Some(block) = visible_block {
-                        self.schedule_position_save(block);
+                    if let Some(height) = height {
+                        self.continuous_scroll.record_height(chapter_idx, height);
                     }
-                } else {
-                    let page_rect = ui.available_rect_before_wrap();
-                    self.paging_page_rect = Some(page_rect);
-                    if dual_column {
-                        let col_w = (page_rect.width() - DUAL_COLUMN_GAP) / 2.0;
-                        let left_rect = egui::Rect::from_min_size(
-                            page_rect.min,
-                            egui::vec2(col_w, page_rect.height()),
-                        );
-                        let right_rect = egui::Rect::from_min_size(
-                            egui::pos2(page_rect.min.x + col_w + DUAL_COLUMN_GAP, page_rect.min.y),
-                            egui::vec2(col_w, page_rect.height()),
-                        );
-                        let right_page = self.current_page + 1;
-                        let is_anim_dual = self.reader_page_animation != "None"
-                            && self.page_anim_progress < 1.0
-                            && (self.page_anim_from != self.page_anim_to
-                                || self.page_anim_cross_chapter);
-                        if is_anim_dual {
-                            let t = self.page_anim_progress;
-                            let w = page_rect.width();
-                            let dir = self.page_anim_direction;
-                            let to_offset = egui::vec2(dir * (1.0 - t) * w, 0.0);
-                            // "from" spread (sliding out, or static for Cover)
-                            {
-                                let from_offset = if self.reader_page_animation == "Cover" {
-                                    egui::vec2(0.0, 0.0)
-                                } else {
-                                    egui::vec2(-dir * t * w, 0.0)
-                                };
-                                if let Some(snap) = &self.page_anim_cross_chapter_snapshot {
-                                    let snap_blocks = Arc::clone(&snap.blocks);
-                                    let snap_ranges = snap.block_ranges.clone();
-                                    let snap_total = snap.total_pages;
-                                    let snap_from = snap.from_page;
-                                    let snap_title = snap.title.clone();
-                                    let from_raw = snap_from.min(snap_total.saturating_sub(1));
-                                    let from_left = (from_raw / 2) * 2;
-                                    let (fls, fle) = snap_ranges
-                                        .get(from_left)
-                                        .copied()
-                                        .map(|(s, e)| {
-                                            (s.min(snap_blocks.len()), e.min(snap_blocks.len()))
-                                        })
-                                        .unwrap_or((0, snap_blocks.len()));
-                                    let left_from_rect = left_rect.translate(from_offset);
-                                    ui.allocate_new_ui(
-                                        UiBuilder::new().max_rect(left_from_rect),
-                                        |ui| {
-                                            let clip = left_from_rect.intersect(page_rect);
-                                            ui.set_clip_rect(clip);
-                                            ui.painter().rect_filled(
-                                                clip,
-                                                0.0,
-                                                self.reader_bg_color,
-                                            );
-                                            render_content_layout(
-                                                ui,
-                                                h_margin,
-                                                text_width,
-                                                &snap_title,
-                                                &snap_blocks,
-                                                fls,
-                                                fle,
-                                                from_left == 0,
-                                                self.font_size,
-                                                self.title_font_scale,
-                                                self.reader_bg_color,
-                                                self.current_chapter,
-                                                total_ch,
-                                                &mut action_prev_chapter,
-                                                &mut action_next_chapter,
-                                                &mut action_go_back,
-                                                false,
-                                                has_previous_chapter,
-                                                self.reader_font_color,
-                                                &effective_font_family,
-                                                &self.i18n,
-                                                &mut clicked_link,
-                                                &highlight_ranges,
-                                            );
-                                        },
-                                    );
-                                    let from_right = from_left + 1;
-                                    if from_right < snap_total {
-                                        let (frs, fre) = snap_ranges
-                                            .get(from_right)
-                                            .copied()
-                                            .map(|(s, e)| {
-                                                (s.min(snap_blocks.len()), e.min(snap_blocks.len()))
-                                            })
-                                            .unwrap_or((0, 0));
-                                        let right_from_rect = right_rect.translate(from_offset);
-                                        ui.allocate_new_ui(
-                                            UiBuilder::new().max_rect(right_from_rect),
-                                            |ui| {
-                                                let clip = right_from_rect.intersect(page_rect);
-                                                ui.set_clip_rect(clip);
-                                                ui.painter().rect_filled(
-                                                    clip,
-                                                    0.0,
-                                                    self.reader_bg_color,
-                                                );
-                                                render_content_layout(
-                                                    ui,
-                                                    h_margin,
-                                                    text_width,
-                                                    &snap_title,
-                                                    &snap_blocks,
-                                                    frs,
-                                                    fre,
-                                                    false,
-                                                    self.font_size,
-                                                    self.title_font_scale,
-                                                    self.reader_bg_color,
-                                                    self.current_chapter,
-                                                    total_ch,
-                                                    &mut action_prev_chapter,
-                                                    &mut action_next_chapter,
-                                                    &mut action_go_back,
-                                                    false,
-                                                    has_previous_chapter,
-                                                    self.reader_font_color,
-                                                    &effective_font_family,
-                                                    &self.i18n,
-                                                    &mut clicked_link,
-                                                    &highlight_ranges,
-                                                );
-                                            },
-                                        );
-                                    }
-                                } else {
-                                    let from_raw =
-                                        self.page_anim_from.min(self.total_pages.saturating_sub(1));
-                                    let from_left = (from_raw / 2) * 2;
-                                    let (fls, fle) = self
-                                        .page_block_ranges
-                                        .get(from_left)
-                                        .copied()
-                                        .map(|(s, e)| (s.min(blocks.len()), e.min(blocks.len())))
-                                        .unwrap_or((0, blocks.len()));
-                                    let left_from_rect = left_rect.translate(from_offset);
-                                    ui.allocate_new_ui(
-                                        UiBuilder::new().max_rect(left_from_rect),
-                                        |ui| {
-                                            let clip = left_from_rect.intersect(page_rect);
-                                            ui.set_clip_rect(clip);
-                                            ui.painter().rect_filled(
-                                                clip,
-                                                0.0,
-                                                self.reader_bg_color,
-                                            );
-                                            render_content_layout(
-                                                ui,
-                                                h_margin,
-                                                text_width,
-                                                &title,
-                                                &blocks,
-                                                fls,
-                                                fle,
-                                                from_left == 0,
-                                                self.font_size,
-                                                self.title_font_scale,
-                                                self.reader_bg_color,
-                                                self.current_chapter,
-                                                total_ch,
-                                                &mut action_prev_chapter,
-                                                &mut action_next_chapter,
-                                                &mut action_go_back,
-                                                false,
-                                                has_previous_chapter,
-                                                self.reader_font_color,
-                                                &effective_font_family,
-                                                &self.i18n,
-                                                &mut clicked_link,
-                                                &highlight_ranges,
-                                            );
-                                        },
-                                    );
-                                    let from_right = from_left + 1;
-                                    if from_right < self.total_pages {
-                                        let (frs, fre) = self
-                                            .page_block_ranges
-                                            .get(from_right)
-                                            .copied()
-                                            .map(|(s, e)| {
-                                                (s.min(blocks.len()), e.min(blocks.len()))
-                                            })
-                                            .unwrap_or((0, 0));
-                                        let right_from_rect = right_rect.translate(from_offset);
-                                        ui.allocate_new_ui(
-                                            UiBuilder::new().max_rect(right_from_rect),
-                                            |ui| {
-                                                let clip = right_from_rect.intersect(page_rect);
-                                                ui.set_clip_rect(clip);
-                                                ui.painter().rect_filled(
-                                                    clip,
-                                                    0.0,
-                                                    self.reader_bg_color,
-                                                );
-                                                render_content_layout(
-                                                    ui,
-                                                    h_margin,
-                                                    text_width,
-                                                    &title,
-                                                    &blocks,
-                                                    frs,
-                                                    fre,
-                                                    false,
-                                                    self.font_size,
-                                                    self.title_font_scale,
-                                                    self.reader_bg_color,
-                                                    self.current_chapter,
-                                                    total_ch,
-                                                    &mut action_prev_chapter,
-                                                    &mut action_next_chapter,
-                                                    &mut action_go_back,
-                                                    false,
-                                                    has_previous_chapter,
-                                                    self.reader_font_color,
-                                                    &effective_font_family,
-                                                    &self.i18n,
-                                                    &mut clicked_link,
-                                                    &highlight_ranges,
-                                                );
-                                            },
-                                        );
-                                    }
-                                }
-
-                                // Cover animation: shadow on leading edge of incoming spread
-                                if self.reader_page_animation == "Cover" {
-                                    let to_rect_pos = left_rect.translate(to_offset);
-                                    let shadow_w = 28.0f32;
-                                    let steps = 8u32;
-                                    for i in 0..steps {
-                                        let sub_w = shadow_w / steps as f32;
-                                        let (sub_x, alpha_val) = if dir > 0.0 {
-                                            let x =
-                                                to_rect_pos.left() - shadow_w + i as f32 * sub_w;
-                                            let a = ((i + 1) as f32 * 70.0 / steps as f32) as u8;
-                                            (x, a)
-                                        } else {
-                                            let x = to_rect_pos.right()
-                                                + (page_rect.width() - left_rect.width())
-                                                + i as f32 * sub_w;
-                                            let a =
-                                                ((steps - i) as f32 * 70.0 / steps as f32) as u8;
-                                            (x, a)
-                                        };
-                                        let sub_rect = egui::Rect::from_min_size(
-                                            egui::pos2(sub_x, page_rect.top()),
-                                            egui::vec2(sub_w, page_rect.height()),
-                                        );
-                                        ui.painter().rect_filled(
-                                            sub_rect,
-                                            0.0,
-                                            Color32::from_black_alpha(alpha_val),
-                                        );
-                                    }
-                                }
-                            }
-                            // "to" spread (sliding in)
-                            let to_raw = self.page_anim_to.min(self.total_pages.saturating_sub(1));
-                            let to_left = (to_raw / 2) * 2;
-                            let (tls, tle) = self
-                                .page_block_ranges
-                                .get(to_left)
-                                .copied()
-                                .map(|(s, e)| (s.min(blocks.len()), e.min(blocks.len())))
-                                .unwrap_or((0, blocks.len()));
-                            let left_to_rect = left_rect.translate(to_offset);
-                            ui.allocate_new_ui(UiBuilder::new().max_rect(left_to_rect), |ui| {
-                                let clip = left_to_rect.intersect(page_rect);
-                                ui.set_clip_rect(clip);
-                                ui.painter().rect_filled(clip, 0.0, self.reader_bg_color);
-                                render_content_layout(
-                                    ui,
-                                    h_margin,
-                                    text_width,
-                                    &title,
-                                    &blocks,
-                                    tls,
-                                    tle,
-                                    to_left == 0,
-                                    self.font_size,
-                                    self.title_font_scale,
-                                    self.reader_bg_color,
-                                    self.current_chapter,
-                                    total_ch,
-                                    &mut action_prev_chapter,
-                                    &mut action_next_chapter,
-                                    &mut action_go_back,
-                                    false,
-                                    has_previous_chapter,
-                                    self.reader_font_color,
-                                    &effective_font_family,
-                                    &self.i18n,
-                                    &mut clicked_link,
-                                    &highlight_ranges,
-                                );
-                            });
-                            let to_right = to_left + 1;
-                            if to_right < self.total_pages {
-                                let (trs, tre) = self
-                                    .page_block_ranges
-                                    .get(to_right)
+                }
+                let visible_block = BLOCK_GALLEYS.with(|galleys| {
+                    galleys
+                        .borrow()
+                        .iter()
+                        .filter(|entry| entry.rect.intersects(viewport))
+                        .min_by(|a, b| a.rect.top().total_cmp(&b.rect.top()))
+                        .map(|entry| (entry.key.chapter, entry.key.block))
+                });
+                if let Some((chapter, block)) = visible_block {
+                    self.continuous_scroll.set_visible_chapter(chapter);
+                    self.schedule_position_save(chapter, block);
+                }
+                if scroll_output.content_size.y - scroll_output.state.offset.y
+                    < scroll_output.inner_rect.height().max(600.0)
+                    && self.continuous_scroll.append_next(total_ch).is_some()
+                {
+                    ui.ctx().request_repaint();
+                }
+            } else {
+                let page_rect = ui.available_rect_before_wrap();
+                self.paging_page_rect = Some(page_rect);
+                if dual_column {
+                    let col_w = (page_rect.width() - DUAL_COLUMN_GAP) / 2.0;
+                    let left_rect = egui::Rect::from_min_size(
+                        page_rect.min,
+                        egui::vec2(col_w, page_rect.height()),
+                    );
+                    let right_rect = egui::Rect::from_min_size(
+                        egui::pos2(page_rect.min.x + col_w + DUAL_COLUMN_GAP, page_rect.min.y),
+                        egui::vec2(col_w, page_rect.height()),
+                    );
+                    let right_page = self.current_page + 1;
+                    let is_anim_dual = self.reader_page_animation != "None"
+                        && self.page_anim_progress < 1.0
+                        && (self.page_anim_from != self.page_anim_to
+                            || self.page_anim_cross_chapter);
+                    if is_anim_dual {
+                        let t = self.page_anim_progress;
+                        let w = page_rect.width();
+                        let dir = self.page_anim_direction;
+                        let to_offset = egui::vec2(dir * (1.0 - t) * w, 0.0);
+                        // "from" spread (sliding out, or static for Cover)
+                        {
+                            let from_offset = if self.reader_page_animation == "Cover" {
+                                egui::vec2(0.0, 0.0)
+                            } else {
+                                egui::vec2(-dir * t * w, 0.0)
+                            };
+                            if let Some(snap) = &self.page_anim_cross_chapter_snapshot {
+                                let snap_blocks = Arc::clone(&snap.blocks);
+                                let snap_ranges = snap.block_ranges.clone();
+                                let snap_total = snap.total_pages;
+                                let snap_from = snap.from_page;
+                                let snap_title = snap.title.clone();
+                                let snap_chapter = snap.chapter;
+                                let from_raw = snap_from.min(snap_total.saturating_sub(1));
+                                let from_left = (from_raw / 2) * 2;
+                                let (fls, fle) = snap_ranges
+                                    .get(from_left)
                                     .copied()
-                                    .map(|(s, e)| (s.min(blocks.len()), e.min(blocks.len())))
-                                    .unwrap_or((0, 0));
-                                let right_to_rect = right_rect.translate(to_offset);
+                                    .map(|(s, e)| {
+                                        (s.min(snap_blocks.len()), e.min(snap_blocks.len()))
+                                    })
+                                    .unwrap_or((0, snap_blocks.len()));
+                                let left_from_rect = left_rect.translate(from_offset);
                                 ui.allocate_new_ui(
-                                    UiBuilder::new().max_rect(right_to_rect),
+                                    UiBuilder::new().max_rect(left_from_rect),
                                     |ui| {
-                                        let clip = right_to_rect.intersect(page_rect);
+                                        let clip = left_from_rect.intersect(page_rect);
                                         ui.set_clip_rect(clip);
                                         ui.painter().rect_filled(clip, 0.0, self.reader_bg_color);
                                         render_content_layout(
                                             ui,
                                             h_margin,
                                             text_width,
-                                            &title,
-                                            &blocks,
-                                            trs,
-                                            tre,
-                                            false,
+                                            &snap_title,
+                                            &snap_blocks,
+                                            fls,
+                                            fle,
+                                            from_left == 0,
                                             self.font_size,
                                             self.title_font_scale,
                                             self.reader_bg_color,
@@ -628,150 +483,20 @@ impl ReaderApp {
                                         );
                                     },
                                 );
-                            }
-                        } else {
-                            ui.allocate_new_ui(UiBuilder::new().max_rect(left_rect), |ui| {
-                                render_content_layout(
-                                    ui,
-                                    h_margin,
-                                    text_width,
-                                    &title,
-                                    &blocks,
-                                    block_start,
-                                    block_end,
-                                    show_title,
-                                    self.font_size,
-                                    self.title_font_scale,
-                                    self.reader_bg_color,
-                                    self.current_chapter,
-                                    total_ch,
-                                    &mut action_prev_chapter,
-                                    &mut action_next_chapter,
-                                    &mut action_go_back,
-                                    false,
-                                    has_previous_chapter,
-                                    self.reader_font_color,
-                                    &effective_font_family,
-                                    &self.i18n,
-                                    &mut clicked_link,
-                                    &highlight_ranges,
-                                );
-                            });
-                            if right_page < self.total_pages {
-                                let (rs, re) =
-                                    if let Some(&(s, e)) = self.page_block_ranges.get(right_page) {
-                                        (s.min(blocks.len()), e.min(blocks.len()))
-                                    } else {
-                                        (0, 0)
-                                    };
-                                ui.allocate_new_ui(UiBuilder::new().max_rect(right_rect), |ui| {
-                                    render_content_layout(
-                                        ui,
-                                        h_margin,
-                                        text_width,
-                                        &title,
-                                        &blocks,
-                                        rs,
-                                        re,
-                                        right_page == 0,
-                                        self.font_size,
-                                        self.title_font_scale,
-                                        self.reader_bg_color,
-                                        self.current_chapter,
-                                        total_ch,
-                                        &mut action_prev_chapter,
-                                        &mut action_next_chapter,
-                                        &mut action_go_back,
-                                        false,
-                                        has_previous_chapter,
-                                        self.reader_font_color,
-                                        &effective_font_family,
-                                        &self.i18n,
-                                        &mut clicked_link,
-                                        &highlight_ranges,
-                                    );
-                                });
-                            }
-                        }
-                        if !is_anim_dual {
-                            let sep_x = page_rect.min.x + col_w + DUAL_COLUMN_GAP / 2.0;
-                            ui.painter().line_segment(
-                                [
-                                    egui::pos2(sep_x, page_rect.top() + 20.0),
-                                    egui::pos2(sep_x, page_rect.bottom() - 20.0),
-                                ],
-                                egui::Stroke::new(1.0_f32, Color32::from_gray(80)),
-                            );
-                        }
-                        let page_info = if right_page < self.total_pages {
-                            format!(
-                                "{}-{} / {}",
-                                self.current_page + 1,
-                                right_page + 1,
-                                self.total_pages
-                            )
-                        } else {
-                            format!("{} / {}", self.current_page + 1, self.total_pages)
-                        };
-                        ui.painter().text(
-                            egui::pos2(page_rect.right() - 20.0, page_rect.top() + 8.0),
-                            egui::Align2::RIGHT_TOP,
-                            page_info,
-                            FontId::proportional(13.0),
-                            Color32::GRAY,
-                        );
-                        ui.painter().text(
-                            egui::pos2(page_rect.right() - 20.0, page_rect.bottom() - 8.0),
-                            egui::Align2::RIGHT_BOTTOM,
-                            self.i18n.tf2(
-                                "reader.chapter_indicator",
-                                &(self.current_chapter + 1).to_string(),
-                                &total_ch.to_string(),
-                            ),
-                            FontId::proportional(13.0),
-                            Color32::GRAY,
-                        );
-                    } else {
-                        let is_animating = self.reader_page_animation != "None"
-                            && self.page_anim_progress < 1.0
-                            && (self.page_anim_from != self.page_anim_to
-                                || self.page_anim_cross_chapter);
-
-                        if is_animating {
-                            let t = self.page_anim_progress;
-                            let w = page_rect.width();
-                            let dir = self.page_anim_direction;
-                            let to_offset = egui::vec2(dir * (1.0 - t) * w, 0.0);
-
-                            let to_idx = self.page_anim_to.min(self.total_pages.saturating_sub(1));
-                            let (ts, te) = self
-                                .page_block_ranges
-                                .get(to_idx)
-                                .copied()
-                                .unwrap_or((0, blocks.len()));
-
-                            {
-                                let from_offset = if self.reader_page_animation == "Cover" {
-                                    egui::vec2(0.0, 0.0)
-                                } else {
-                                    egui::vec2(-dir * t * w, 0.0)
-                                };
-                                if let Some(snap) = &self.page_anim_cross_chapter_snapshot {
-                                    let snap_blocks = Arc::clone(&snap.blocks);
-                                    let snap_ranges = snap.block_ranges.clone();
-                                    let snap_total = snap.total_pages;
-                                    let snap_from = snap.from_page;
-                                    let snap_title = snap.title.clone();
-                                    let from_idx = snap_from.min(snap_total.saturating_sub(1));
-                                    let (fs, fe) = snap_ranges
-                                        .get(from_idx)
+                                let from_right = from_left + 1;
+                                if from_right < snap_total {
+                                    let (frs, fre) = snap_ranges
+                                        .get(from_right)
                                         .copied()
-                                        .unwrap_or((0, snap_blocks.len()));
-                                    let from_rect = page_rect.translate(from_offset);
+                                        .map(|(s, e)| {
+                                            (s.min(snap_blocks.len()), e.min(snap_blocks.len()))
+                                        })
+                                        .unwrap_or((0, 0));
+                                    let right_from_rect = right_rect.translate(from_offset);
                                     ui.allocate_new_ui(
-                                        UiBuilder::new().max_rect(from_rect),
+                                        UiBuilder::new().max_rect(right_from_rect),
                                         |ui| {
-                                            let clip = from_rect.intersect(page_rect);
+                                            let clip = right_from_rect.intersect(page_rect);
                                             ui.set_clip_rect(clip);
                                             ui.painter().rect_filled(
                                                 clip,
@@ -784,13 +509,13 @@ impl ReaderApp {
                                                 text_width,
                                                 &snap_title,
                                                 &snap_blocks,
-                                                fs.min(snap_blocks.len()),
-                                                fe.min(snap_blocks.len()),
-                                                from_idx == 0,
+                                                frs,
+                                                fre,
+                                                false,
                                                 self.font_size,
                                                 self.title_font_scale,
                                                 self.reader_bg_color,
-                                                self.current_chapter,
+                                                snap_chapter,
                                                 total_ch,
                                                 &mut action_prev_chapter,
                                                 &mut action_next_chapter,
@@ -805,19 +530,64 @@ impl ReaderApp {
                                             );
                                         },
                                     );
-                                } else {
-                                    let from_idx =
-                                        self.page_anim_from.min(self.total_pages.saturating_sub(1));
-                                    let (fs, fe) = self
+                                }
+                            } else {
+                                let from_raw =
+                                    self.page_anim_from.min(self.total_pages.saturating_sub(1));
+                                let from_left = (from_raw / 2) * 2;
+                                let (fls, fle) = self
+                                    .page_block_ranges
+                                    .get(from_left)
+                                    .copied()
+                                    .map(|(s, e)| (s.min(blocks.len()), e.min(blocks.len())))
+                                    .unwrap_or((0, blocks.len()));
+                                let left_from_rect = left_rect.translate(from_offset);
+                                ui.allocate_new_ui(
+                                    UiBuilder::new().max_rect(left_from_rect),
+                                    |ui| {
+                                        let clip = left_from_rect.intersect(page_rect);
+                                        ui.set_clip_rect(clip);
+                                        ui.painter().rect_filled(clip, 0.0, self.reader_bg_color);
+                                        render_content_layout(
+                                            ui,
+                                            h_margin,
+                                            text_width,
+                                            &title,
+                                            &blocks,
+                                            fls,
+                                            fle,
+                                            from_left == 0,
+                                            self.font_size,
+                                            self.title_font_scale,
+                                            self.reader_bg_color,
+                                            self.current_chapter,
+                                            total_ch,
+                                            &mut action_prev_chapter,
+                                            &mut action_next_chapter,
+                                            &mut action_go_back,
+                                            false,
+                                            has_previous_chapter,
+                                            self.reader_font_color,
+                                            &effective_font_family,
+                                            &self.i18n,
+                                            &mut clicked_link,
+                                            &highlight_ranges,
+                                        );
+                                    },
+                                );
+                                let from_right = from_left + 1;
+                                if from_right < self.total_pages {
+                                    let (frs, fre) = self
                                         .page_block_ranges
-                                        .get(from_idx)
+                                        .get(from_right)
                                         .copied()
-                                        .unwrap_or((0, blocks.len()));
-                                    let from_rect = page_rect.translate(from_offset);
+                                        .map(|(s, e)| (s.min(blocks.len()), e.min(blocks.len())))
+                                        .unwrap_or((0, 0));
+                                    let right_from_rect = right_rect.translate(from_offset);
                                     ui.allocate_new_ui(
-                                        UiBuilder::new().max_rect(from_rect),
+                                        UiBuilder::new().max_rect(right_from_rect),
                                         |ui| {
-                                            let clip = from_rect.intersect(page_rect);
+                                            let clip = right_from_rect.intersect(page_rect);
                                             ui.set_clip_rect(clip);
                                             ui.painter().rect_filled(
                                                 clip,
@@ -830,9 +600,9 @@ impl ReaderApp {
                                                 text_width,
                                                 &title,
                                                 &blocks,
-                                                fs.min(blocks.len()),
-                                                fe.min(blocks.len()),
-                                                from_idx == 0,
+                                                frs,
+                                                fre,
+                                                false,
                                                 self.font_size,
                                                 self.title_font_scale,
                                                 self.reader_bg_color,
@@ -852,42 +622,89 @@ impl ReaderApp {
                                         },
                                     );
                                 }
-
-                                // Cover animation: draw shadow on leading edge of incoming page
-                                if self.reader_page_animation == "Cover" {
-                                    let to_rect_pos = page_rect.translate(to_offset);
-                                    let shadow_w = 28.0f32;
-                                    let steps = 8u32;
-                                    for i in 0..steps {
-                                        let sub_w = shadow_w / steps as f32;
-                                        let (sub_x, alpha_val) = if dir > 0.0 {
-                                            let x =
-                                                to_rect_pos.left() - shadow_w + i as f32 * sub_w;
-                                            let a = ((i + 1) as f32 * 70.0 / steps as f32) as u8;
-                                            (x, a)
-                                        } else {
-                                            let x = to_rect_pos.right() + i as f32 * sub_w;
-                                            let a =
-                                                ((steps - i) as f32 * 70.0 / steps as f32) as u8;
-                                            (x, a)
-                                        };
-                                        let sub_rect = egui::Rect::from_min_size(
-                                            egui::pos2(sub_x, page_rect.top()),
-                                            egui::vec2(sub_w, page_rect.height()),
-                                        );
-                                        ui.painter().rect_filled(
-                                            sub_rect,
-                                            0.0,
-                                            Color32::from_black_alpha(alpha_val),
-                                        );
-                                    }
-                                }
                             }
 
-                            let to_rect = page_rect.translate(to_offset);
-
-                            ui.allocate_new_ui(UiBuilder::new().max_rect(to_rect), |ui| {
-                                let clip = to_rect.intersect(page_rect);
+                            // Cover animation: shadow on leading edge of incoming spread
+                            if self.reader_page_animation == "Cover" {
+                                let to_rect_pos = left_rect.translate(to_offset);
+                                let shadow_w = 28.0f32;
+                                let steps = 8u32;
+                                for i in 0..steps {
+                                    let sub_w = shadow_w / steps as f32;
+                                    let (sub_x, alpha_val) = if dir > 0.0 {
+                                        let x = to_rect_pos.left() - shadow_w + i as f32 * sub_w;
+                                        let a = ((i + 1) as f32 * 70.0 / steps as f32) as u8;
+                                        (x, a)
+                                    } else {
+                                        let x = to_rect_pos.right()
+                                            + (page_rect.width() - left_rect.width())
+                                            + i as f32 * sub_w;
+                                        let a = ((steps - i) as f32 * 70.0 / steps as f32) as u8;
+                                        (x, a)
+                                    };
+                                    let sub_rect = egui::Rect::from_min_size(
+                                        egui::pos2(sub_x, page_rect.top()),
+                                        egui::vec2(sub_w, page_rect.height()),
+                                    );
+                                    ui.painter().rect_filled(
+                                        sub_rect,
+                                        0.0,
+                                        Color32::from_black_alpha(alpha_val),
+                                    );
+                                }
+                            }
+                        }
+                        // "to" spread (sliding in)
+                        let to_raw = self.page_anim_to.min(self.total_pages.saturating_sub(1));
+                        let to_left = (to_raw / 2) * 2;
+                        let (tls, tle) = self
+                            .page_block_ranges
+                            .get(to_left)
+                            .copied()
+                            .map(|(s, e)| (s.min(blocks.len()), e.min(blocks.len())))
+                            .unwrap_or((0, blocks.len()));
+                        let left_to_rect = left_rect.translate(to_offset);
+                        ui.allocate_new_ui(UiBuilder::new().max_rect(left_to_rect), |ui| {
+                            let clip = left_to_rect.intersect(page_rect);
+                            ui.set_clip_rect(clip);
+                            ui.painter().rect_filled(clip, 0.0, self.reader_bg_color);
+                            render_content_layout(
+                                ui,
+                                h_margin,
+                                text_width,
+                                &title,
+                                &blocks,
+                                tls,
+                                tle,
+                                to_left == 0,
+                                self.font_size,
+                                self.title_font_scale,
+                                self.reader_bg_color,
+                                self.current_chapter,
+                                total_ch,
+                                &mut action_prev_chapter,
+                                &mut action_next_chapter,
+                                &mut action_go_back,
+                                false,
+                                has_previous_chapter,
+                                self.reader_font_color,
+                                &effective_font_family,
+                                &self.i18n,
+                                &mut clicked_link,
+                                &highlight_ranges,
+                            );
+                        });
+                        let to_right = to_left + 1;
+                        if to_right < self.total_pages {
+                            let (trs, tre) = self
+                                .page_block_ranges
+                                .get(to_right)
+                                .copied()
+                                .map(|(s, e)| (s.min(blocks.len()), e.min(blocks.len())))
+                                .unwrap_or((0, 0));
+                            let right_to_rect = right_rect.translate(to_offset);
+                            ui.allocate_new_ui(UiBuilder::new().max_rect(right_to_rect), |ui| {
+                                let clip = right_to_rect.intersect(page_rect);
                                 ui.set_clip_rect(clip);
                                 ui.painter().rect_filled(clip, 0.0, self.reader_bg_color);
                                 render_content_layout(
@@ -896,9 +713,9 @@ impl ReaderApp {
                                     text_width,
                                     &title,
                                     &blocks,
-                                    ts.min(blocks.len()),
-                                    te.min(blocks.len()),
-                                    to_idx == 0,
+                                    trs,
+                                    tre,
+                                    false,
                                     self.font_size,
                                     self.title_font_scale,
                                     self.reader_bg_color,
@@ -916,7 +733,9 @@ impl ReaderApp {
                                     &highlight_ranges,
                                 );
                             });
-                        } else {
+                        }
+                    } else {
+                        ui.allocate_new_ui(UiBuilder::new().max_rect(left_rect), |ui| {
                             render_content_layout(
                                 ui,
                                 h_margin,
@@ -942,71 +761,341 @@ impl ReaderApp {
                                 &mut clicked_link,
                                 &highlight_ranges,
                             );
+                        });
+                        if right_page < self.total_pages {
+                            let (rs, re) =
+                                if let Some(&(s, e)) = self.page_block_ranges.get(right_page) {
+                                    (s.min(blocks.len()), e.min(blocks.len()))
+                                } else {
+                                    (0, 0)
+                                };
+                            ui.allocate_new_ui(UiBuilder::new().max_rect(right_rect), |ui| {
+                                render_content_layout(
+                                    ui,
+                                    h_margin,
+                                    text_width,
+                                    &title,
+                                    &blocks,
+                                    rs,
+                                    re,
+                                    right_page == 0,
+                                    self.font_size,
+                                    self.title_font_scale,
+                                    self.reader_bg_color,
+                                    self.current_chapter,
+                                    total_ch,
+                                    &mut action_prev_chapter,
+                                    &mut action_next_chapter,
+                                    &mut action_go_back,
+                                    false,
+                                    has_previous_chapter,
+                                    self.reader_font_color,
+                                    &effective_font_family,
+                                    &self.i18n,
+                                    &mut clicked_link,
+                                    &highlight_ranges,
+                                );
+                            });
                         }
-                        ui.painter().text(
-                            egui::pos2(page_rect.right() - 20.0, page_rect.top() + 8.0),
-                            egui::Align2::RIGHT_TOP,
-                            format!("{} / {}", self.current_page + 1, self.total_pages),
-                            FontId::proportional(13.0),
-                            Color32::GRAY,
-                        );
-                        ui.painter().text(
-                            egui::pos2(page_rect.right() - 20.0, page_rect.bottom() - 8.0),
-                            egui::Align2::RIGHT_BOTTOM,
-                            self.i18n.tf2(
-                                "reader.chapter_indicator",
-                                &(self.current_chapter + 1).to_string(),
-                                &total_ch.to_string(),
-                            ),
-                            FontId::proportional(13.0),
-                            Color32::GRAY,
+                    }
+                    if !is_anim_dual {
+                        let sep_x = page_rect.min.x + col_w + DUAL_COLUMN_GAP / 2.0;
+                        ui.painter().line_segment(
+                            [
+                                egui::pos2(sep_x, page_rect.top() + 20.0),
+                                egui::pos2(sep_x, page_rect.bottom() - 20.0),
+                            ],
+                            egui::Stroke::new(1.0_f32, Color32::from_gray(80)),
                         );
                     }
-                    if !self.show_sharing_panel
-                        && !self.show_stats
-                        && !self.show_export_dialog
-                        && self.text_selection.is_none()
-                        && self.clicked_highlight_id.is_none()
-                        && self.csc_popup.is_none()
-                        && !self.csc_custom_replace_active
-                        && !self.show_review_panel
-                    {
-                        let pointer_in_page = ui.input(|i| {
-                            i.pointer
-                                .hover_pos()
-                                .map(|pos| page_rect.contains(pos))
-                                .unwrap_or(false)
-                        });
-                        if pointer_in_page {
-                            let scroll = ui.input(|i| i.raw_scroll_delta.y);
-                            if scroll < -30.0 {
-                                action_next_page = true;
-                            } else if scroll > 30.0 {
-                                action_prev_page = true;
+                    let page_info = if right_page < self.total_pages {
+                        format!(
+                            "{}-{} / {}",
+                            self.current_page + 1,
+                            right_page + 1,
+                            self.total_pages
+                        )
+                    } else {
+                        format!("{} / {}", self.current_page + 1, self.total_pages)
+                    };
+                    ui.painter().text(
+                        egui::pos2(page_rect.right() - 20.0, page_rect.top() + 8.0),
+                        egui::Align2::RIGHT_TOP,
+                        page_info,
+                        FontId::proportional(13.0),
+                        Color32::GRAY,
+                    );
+                    ui.painter().text(
+                        egui::pos2(page_rect.right() - 20.0, page_rect.bottom() - 8.0),
+                        egui::Align2::RIGHT_BOTTOM,
+                        self.i18n.tf2(
+                            "reader.chapter_indicator",
+                            &(self.current_chapter + 1).to_string(),
+                            &total_ch.to_string(),
+                        ),
+                        FontId::proportional(13.0),
+                        Color32::GRAY,
+                    );
+                } else {
+                    let is_animating = self.reader_page_animation != "None"
+                        && self.page_anim_progress < 1.0
+                        && (self.page_anim_from != self.page_anim_to
+                            || self.page_anim_cross_chapter);
+
+                    if is_animating {
+                        let t = self.page_anim_progress;
+                        let w = page_rect.width();
+                        let dir = self.page_anim_direction;
+                        let to_offset = egui::vec2(dir * (1.0 - t) * w, 0.0);
+
+                        let to_idx = self.page_anim_to.min(self.total_pages.saturating_sub(1));
+                        let (ts, te) = self
+                            .page_block_ranges
+                            .get(to_idx)
+                            .copied()
+                            .unwrap_or((0, blocks.len()));
+
+                        {
+                            let from_offset = if self.reader_page_animation == "Cover" {
+                                egui::vec2(0.0, 0.0)
+                            } else {
+                                egui::vec2(-dir * t * w, 0.0)
+                            };
+                            if let Some(snap) = &self.page_anim_cross_chapter_snapshot {
+                                let snap_blocks = Arc::clone(&snap.blocks);
+                                let snap_ranges = snap.block_ranges.clone();
+                                let snap_total = snap.total_pages;
+                                let snap_from = snap.from_page;
+                                let snap_title = snap.title.clone();
+                                let snap_chapter = snap.chapter;
+                                let from_idx = snap_from.min(snap_total.saturating_sub(1));
+                                let (fs, fe) = snap_ranges
+                                    .get(from_idx)
+                                    .copied()
+                                    .unwrap_or((0, snap_blocks.len()));
+                                let from_rect = page_rect.translate(from_offset);
+                                ui.allocate_new_ui(UiBuilder::new().max_rect(from_rect), |ui| {
+                                    let clip = from_rect.intersect(page_rect);
+                                    ui.set_clip_rect(clip);
+                                    ui.painter().rect_filled(clip, 0.0, self.reader_bg_color);
+                                    render_content_layout(
+                                        ui,
+                                        h_margin,
+                                        text_width,
+                                        &snap_title,
+                                        &snap_blocks,
+                                        fs.min(snap_blocks.len()),
+                                        fe.min(snap_blocks.len()),
+                                        from_idx == 0,
+                                        self.font_size,
+                                        self.title_font_scale,
+                                        self.reader_bg_color,
+                                        snap_chapter,
+                                        total_ch,
+                                        &mut action_prev_chapter,
+                                        &mut action_next_chapter,
+                                        &mut action_go_back,
+                                        false,
+                                        has_previous_chapter,
+                                        self.reader_font_color,
+                                        &effective_font_family,
+                                        &self.i18n,
+                                        &mut clicked_link,
+                                        &highlight_ranges,
+                                    );
+                                });
+                            } else {
+                                let from_idx =
+                                    self.page_anim_from.min(self.total_pages.saturating_sub(1));
+                                let (fs, fe) = self
+                                    .page_block_ranges
+                                    .get(from_idx)
+                                    .copied()
+                                    .unwrap_or((0, blocks.len()));
+                                let from_rect = page_rect.translate(from_offset);
+                                ui.allocate_new_ui(UiBuilder::new().max_rect(from_rect), |ui| {
+                                    let clip = from_rect.intersect(page_rect);
+                                    ui.set_clip_rect(clip);
+                                    ui.painter().rect_filled(clip, 0.0, self.reader_bg_color);
+                                    render_content_layout(
+                                        ui,
+                                        h_margin,
+                                        text_width,
+                                        &title,
+                                        &blocks,
+                                        fs.min(blocks.len()),
+                                        fe.min(blocks.len()),
+                                        from_idx == 0,
+                                        self.font_size,
+                                        self.title_font_scale,
+                                        self.reader_bg_color,
+                                        self.current_chapter,
+                                        total_ch,
+                                        &mut action_prev_chapter,
+                                        &mut action_next_chapter,
+                                        &mut action_go_back,
+                                        false,
+                                        has_previous_chapter,
+                                        self.reader_font_color,
+                                        &effective_font_family,
+                                        &self.i18n,
+                                        &mut clicked_link,
+                                        &highlight_ranges,
+                                    );
+                                });
+                            }
+
+                            // Cover animation: draw shadow on leading edge of incoming page
+                            if self.reader_page_animation == "Cover" {
+                                let to_rect_pos = page_rect.translate(to_offset);
+                                let shadow_w = 28.0f32;
+                                let steps = 8u32;
+                                for i in 0..steps {
+                                    let sub_w = shadow_w / steps as f32;
+                                    let (sub_x, alpha_val) = if dir > 0.0 {
+                                        let x = to_rect_pos.left() - shadow_w + i as f32 * sub_w;
+                                        let a = ((i + 1) as f32 * 70.0 / steps as f32) as u8;
+                                        (x, a)
+                                    } else {
+                                        let x = to_rect_pos.right() + i as f32 * sub_w;
+                                        let a = ((steps - i) as f32 * 70.0 / steps as f32) as u8;
+                                        (x, a)
+                                    };
+                                    let sub_rect = egui::Rect::from_min_size(
+                                        egui::pos2(sub_x, page_rect.top()),
+                                        egui::vec2(sub_w, page_rect.height()),
+                                    );
+                                    ui.painter().rect_filled(
+                                        sub_rect,
+                                        0.0,
+                                        Color32::from_black_alpha(alpha_val),
+                                    );
+                                }
                             }
                         }
-                        // Click-to-turn is handled in the selection release handler
-                        // to avoid conflict with sel_press_origin
-                        if clicked_link.is_none()
-                            && self.sel_press_origin.is_none()
-                            && ui.input(|i| i.pointer.primary_clicked())
-                        {
-                            // Check if click hits a CSC correction (skip page turn if so)
-                            let hit_csc = CSC_RECTS.with(|rects| {
-                                if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
-                                    rects.borrow().iter().any(|cr| cr.rect.contains(pos))
-                                } else {
-                                    false
-                                }
-                            });
-                            if !hit_csc {
-                                if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
-                                    if page_rect.contains(pos) {
-                                        if pos.x < page_rect.center().x {
-                                            action_prev_page = true;
-                                        } else {
-                                            action_next_page = true;
-                                        }
+
+                        let to_rect = page_rect.translate(to_offset);
+
+                        ui.allocate_new_ui(UiBuilder::new().max_rect(to_rect), |ui| {
+                            let clip = to_rect.intersect(page_rect);
+                            ui.set_clip_rect(clip);
+                            ui.painter().rect_filled(clip, 0.0, self.reader_bg_color);
+                            render_content_layout(
+                                ui,
+                                h_margin,
+                                text_width,
+                                &title,
+                                &blocks,
+                                ts.min(blocks.len()),
+                                te.min(blocks.len()),
+                                to_idx == 0,
+                                self.font_size,
+                                self.title_font_scale,
+                                self.reader_bg_color,
+                                self.current_chapter,
+                                total_ch,
+                                &mut action_prev_chapter,
+                                &mut action_next_chapter,
+                                &mut action_go_back,
+                                false,
+                                has_previous_chapter,
+                                self.reader_font_color,
+                                &effective_font_family,
+                                &self.i18n,
+                                &mut clicked_link,
+                                &highlight_ranges,
+                            );
+                        });
+                    } else {
+                        render_content_layout(
+                            ui,
+                            h_margin,
+                            text_width,
+                            &title,
+                            &blocks,
+                            block_start,
+                            block_end,
+                            show_title,
+                            self.font_size,
+                            self.title_font_scale,
+                            self.reader_bg_color,
+                            self.current_chapter,
+                            total_ch,
+                            &mut action_prev_chapter,
+                            &mut action_next_chapter,
+                            &mut action_go_back,
+                            false,
+                            has_previous_chapter,
+                            self.reader_font_color,
+                            &effective_font_family,
+                            &self.i18n,
+                            &mut clicked_link,
+                            &highlight_ranges,
+                        );
+                    }
+                    ui.painter().text(
+                        egui::pos2(page_rect.right() - 20.0, page_rect.top() + 8.0),
+                        egui::Align2::RIGHT_TOP,
+                        format!("{} / {}", self.current_page + 1, self.total_pages),
+                        FontId::proportional(13.0),
+                        Color32::GRAY,
+                    );
+                    ui.painter().text(
+                        egui::pos2(page_rect.right() - 20.0, page_rect.bottom() - 8.0),
+                        egui::Align2::RIGHT_BOTTOM,
+                        self.i18n.tf2(
+                            "reader.chapter_indicator",
+                            &(self.current_chapter + 1).to_string(),
+                            &total_ch.to_string(),
+                        ),
+                        FontId::proportional(13.0),
+                        Color32::GRAY,
+                    );
+                }
+                if !self.show_sharing_panel
+                    && !self.show_stats
+                    && !self.show_export_dialog
+                    && self.text_selection.is_none()
+                    && self.clicked_highlight_id.is_none()
+                    && self.csc_popup.is_none()
+                    && !self.csc_custom_replace_active
+                    && !self.show_review_panel
+                {
+                    let pointer_in_page = ui.input(|i| {
+                        i.pointer
+                            .hover_pos()
+                            .map(|pos| page_rect.contains(pos))
+                            .unwrap_or(false)
+                    });
+                    if pointer_in_page {
+                        let scroll = ui.input(|i| i.raw_scroll_delta.y);
+                        if scroll < -30.0 {
+                            action_next_page = true;
+                        } else if scroll > 30.0 {
+                            action_prev_page = true;
+                        }
+                    }
+                    // Click-to-turn is handled in the selection release handler
+                    // to avoid conflict with sel_press_origin
+                    if clicked_link.is_none()
+                        && self.sel_press_origin.is_none()
+                        && ui.input(|i| i.pointer.primary_clicked())
+                    {
+                        // Check if click hits a CSC correction (skip page turn if so)
+                        let hit_csc = CSC_RECTS.with(|rects| {
+                            if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
+                                rects.borrow().iter().any(|cr| cr.rect.contains(pos))
+                            } else {
+                                false
+                            }
+                        });
+                        if !hit_csc {
+                            if let Some(pos) = ui.input(|i| i.pointer.interact_pos()) {
+                                if page_rect.contains(pos) {
+                                    if pos.x < page_rect.center().x {
+                                        action_prev_page = true;
+                                    } else {
+                                        action_next_page = true;
                                     }
                                 }
                             }
@@ -1132,7 +1221,7 @@ impl ReaderApp {
 
         if !self.scroll_mode {
             if let Some((block, _)) = self.page_block_ranges.get(self.current_page).copied() {
-                self.schedule_position_save(block);
+                self.schedule_position_save(self.current_chapter, block);
             }
         }
 
@@ -1143,15 +1232,15 @@ impl ReaderApp {
         let mut start_reading = None;
         let mut follow_reading = false;
         let mut tts_context_menu_open = false;
-        for (block_idx, galley, rect, _, response) in &block_galleys {
-            let target_id = response.id.with("tts_read_from_here");
-            if response.secondary_clicked() {
-                if let Some(pos) = response.interact_pointer_pos() {
-                    let cursor = galley.cursor_from_pos(pos - rect.min);
+        for entry in &block_galleys {
+            let target_id = entry.response.id.with("tts_read_from_here");
+            if entry.response.secondary_clicked() {
+                if let Some(pos) = entry.response.interact_pointer_pos() {
+                    let cursor = entry.galley.cursor_from_pos(pos - entry.rect.min);
                     ui.ctx().data_mut(|data| {
                         data.insert_temp(
                             target_id,
-                            (self.current_chapter, *block_idx, cursor.ccursor.index),
+                            (entry.key.chapter, entry.key.block, cursor.ccursor.index),
                         );
                     });
                 }
@@ -1159,8 +1248,8 @@ impl ReaderApp {
             let target = ui
                 .ctx()
                 .data(|data| data.get_temp::<(usize, usize, usize)>(target_id));
-            let was_open = response.context_menu_opened();
-            response.context_menu(|ui| {
+            let was_open = entry.response.context_menu_opened();
+            entry.response.context_menu(|ui| {
                 if let Some(target) = target {
                     if ui.button(self.i18n.t("tts.read_from_here")).clicked() {
                         start_reading = Some(target);
@@ -1178,7 +1267,7 @@ impl ReaderApp {
                     ui.close_menu();
                 }
             });
-            tts_context_menu_open |= was_open || response.context_menu_opened();
+            tts_context_menu_open |= was_open || entry.response.context_menu_opened();
         }
         if let Some((chapter, block_idx, char_offset)) = start_reading {
             self.show_tts_panel = true;
@@ -1195,11 +1284,11 @@ impl ReaderApp {
 
         // Helper: find which block a screen position falls into and return (block_idx, char_offset)
         let hit_test = |pos: egui::Pos2| -> Option<(usize, usize)> {
-            for (idx, galley, rect, _text, _) in &block_galleys {
-                if rect.contains(pos) {
-                    let local = egui::vec2(pos.x - rect.min.x, pos.y - rect.min.y);
-                    let cursor = galley.cursor_from_pos(local);
-                    return Some((*idx, cursor.ccursor.index));
+            for entry in &block_galleys {
+                if entry.key.chapter == self.current_chapter && entry.rect.contains(pos) {
+                    let local = egui::vec2(pos.x - entry.rect.min.x, pos.y - entry.rect.min.y);
+                    let cursor = entry.galley.cursor_from_pos(local);
+                    return Some((entry.key.block, cursor.ccursor.index));
                 }
             }
             None
@@ -1259,17 +1348,23 @@ impl ReaderApp {
                             // Pointer is outside any block 鈥?find the closest block
                             // above or below to extend selection
                             let mut best: Option<(usize, usize)> = None;
-                            for (idx, galley, rect, _, _) in &block_galleys {
-                                if pos.y < rect.min.y {
+                            for entry in block_galleys
+                                .iter()
+                                .filter(|entry| entry.key.chapter == self.current_chapter)
+                            {
+                                if pos.y < entry.rect.min.y {
                                     // Above this block 鈫?first char
-                                    if best.as_ref().is_none_or(|(best_idx, _)| *idx < *best_idx) {
-                                        best = Some((*idx, 0));
+                                    if best
+                                        .as_ref()
+                                        .is_none_or(|(best_idx, _)| entry.key.block < *best_idx)
+                                    {
+                                        best = Some((entry.key.block, 0));
                                     }
                                     break;
-                                } else if pos.y > rect.max.y {
+                                } else if pos.y > entry.rect.max.y {
                                     // Below this block 鈫?last char
-                                    let end = galley.text().chars().count();
-                                    best = Some((*idx, end));
+                                    let end = entry.galley.text().chars().count();
+                                    best = Some((entry.key.block, end));
                                 }
                             }
                             if let Some((bi, ci)) = best {
@@ -1304,11 +1399,12 @@ impl ReaderApp {
                                 self.editing_note_buf.clear();
                             }
                             // Position popup above the click point
-                            if let Some((_, _, rect, _, _)) = block_galleys
-                                .iter()
-                                .find(|(idx, _, _, _, _)| *idx == press_block)
-                            {
-                                self.hl_note_toolbar_pos = egui::pos2(rect.center().x, rect.min.y);
+                            if let Some(entry) = block_galleys.iter().find(|entry| {
+                                entry.key.chapter == self.current_chapter
+                                    && entry.key.block == press_block
+                            }) {
+                                self.hl_note_toolbar_pos =
+                                    egui::pos2(entry.rect.center().x, entry.rect.min.y);
                             }
                             // Clear any text selection
                             self.text_selection = None;
@@ -1371,11 +1467,12 @@ impl ReaderApp {
                         } else {
                             // Position the toolbar above the start of the selection
                             let (sel_start_block, _) = sel.normalized();
-                            if let Some((_, _, rect, _, _)) = block_galleys
-                                .iter()
-                                .find(|(idx, _, _, _, _)| *idx == sel_start_block)
-                            {
-                                self.sel_toolbar_pos = egui::pos2(rect.center().x, rect.top());
+                            if let Some(entry) = block_galleys.iter().find(|entry| {
+                                entry.key.chapter == self.current_chapter
+                                    && entry.key.block == sel_start_block
+                            }) {
+                                self.sel_toolbar_pos =
+                                    egui::pos2(entry.rect.center().x, entry.rect.top());
                             }
                         }
                     }
@@ -1386,13 +1483,17 @@ impl ReaderApp {
         // 鈹€鈹€ Draw selection highlight overlay (blue rectangles) 鈹€鈹€
         if let Some(sel) = &self.text_selection {
             let (sb, sc, eb, ec) = sel.normalized_range();
-            for (idx, galley, rect, text, _) in &block_galleys {
-                if *idx < sb || *idx > eb {
+            for entry in block_galleys
+                .iter()
+                .filter(|entry| entry.key.chapter == self.current_chapter)
+            {
+                let idx = entry.key.block;
+                if idx < sb || idx > eb {
                     continue;
                 }
-                let char_len = text.chars().count();
-                let sel_start = if *idx == sb { sc } else { 0 };
-                let sel_end = if *idx == eb {
+                let char_len = entry.text.chars().count();
+                let sel_start = if idx == sb { sc } else { 0 };
+                let sel_end = if idx == eb {
                     ec.min(char_len)
                 } else {
                     char_len
@@ -1401,31 +1502,39 @@ impl ReaderApp {
                     continue;
                 }
                 // Convert char offsets to galley cursors
-                let c_start = galley.from_ccursor(egui::text::CCursor::new(sel_start));
-                let c_end = galley.from_ccursor(egui::text::CCursor::new(sel_end));
+                let c_start = entry
+                    .galley
+                    .from_ccursor(egui::text::CCursor::new(sel_start));
+                let c_end = entry.galley.from_ccursor(egui::text::CCursor::new(sel_end));
                 // Walk galley rows and draw highlight rect for each selected row range
                 let start_row = c_start.rcursor.row;
                 let end_row = c_end.rcursor.row;
                 for row_idx in start_row..=end_row {
-                    if row_idx >= galley.rows.len() {
+                    if row_idx >= entry.galley.rows.len() {
                         break;
                     }
-                    let row = &galley.rows[row_idx];
+                    let row = &entry.galley.rows[row_idx];
                     let row_min_x = if row_idx == start_row {
                         // Start of selection within first row
 
-                        galley.pos_from_cursor(&c_start).min.x
+                        entry.galley.pos_from_cursor(&c_start).min.x
                     } else {
                         row.rect.min.x
                     };
                     let row_max_x = if row_idx == end_row {
-                        galley.pos_from_cursor(&c_end).max.x
+                        entry.galley.pos_from_cursor(&c_end).max.x
                     } else {
                         row.rect.max.x
                     };
                     let hl_rect = egui::Rect::from_min_max(
-                        egui::pos2(rect.min.x + row_min_x, rect.min.y + row.rect.min.y),
-                        egui::pos2(rect.min.x + row_max_x, rect.min.y + row.rect.max.y),
+                        egui::pos2(
+                            entry.rect.min.x + row_min_x,
+                            entry.rect.min.y + row.rect.min.y,
+                        ),
+                        egui::pos2(
+                            entry.rect.min.x + row_max_x,
+                            entry.rect.min.y + row.rect.max.y,
+                        ),
                     );
                     ui.painter().rect_filled(hl_rect, 0.0, SEL_BG);
                 }
@@ -1440,13 +1549,17 @@ impl ReaderApp {
             .map(|sel| {
                 let (sb, sc, eb, ec) = sel.normalized_range();
                 let mut result = String::new();
-                for (idx, _, _, text, _) in &block_galleys {
-                    if *idx < sb || *idx > eb {
+                for entry in block_galleys
+                    .iter()
+                    .filter(|entry| entry.key.chapter == self.current_chapter)
+                {
+                    let idx = entry.key.block;
+                    if idx < sb || idx > eb {
                         continue;
                     }
-                    let chars: Vec<char> = text.chars().collect();
-                    let start = if *idx == sb { sc } else { 0 };
-                    let end = if *idx == eb {
+                    let chars: Vec<char> = entry.text.chars().collect();
+                    let start = if idx == sb { sc } else { 0 };
+                    let end = if idx == eb {
                         ec.min(chars.len())
                     } else {
                         chars.len()
@@ -1490,13 +1603,17 @@ impl ReaderApp {
                         let sel_range = sel.normalized_range();
                         if let Some(cfg) = &mut self.book_config {
                             let (sb, sc, eb, ec) = sel_range;
-                            for (idx, _, _, text, _) in &block_galleys {
-                                if *idx < sb || *idx > eb {
+                            for entry in block_galleys
+                                .iter()
+                                .filter(|entry| entry.key.chapter == self.current_chapter)
+                            {
+                                let idx = entry.key.block;
+                                if idx < sb || idx > eb {
                                     continue;
                                 }
-                                let char_len = text.chars().count();
-                                let start = if *idx == sb { sc } else { 0 };
-                                let end = if *idx == eb {
+                                let char_len = entry.text.chars().count();
+                                let start = if idx == sb { sc } else { 0 };
+                                let end = if idx == eb {
                                     ec.min(char_len)
                                 } else {
                                     char_len
@@ -1505,9 +1622,9 @@ impl ReaderApp {
                                     cfg.highlights.push(reader_core::library::Highlight {
                                         id: format!("{}-{}", reader_core::now_secs(), idx),
                                         chapter: self.current_chapter,
-                                        start_block: *idx,
+                                        start_block: idx,
                                         start_offset: start,
-                                        end_block: *idx,
+                                        end_block: idx,
                                         end_offset: end,
                                         color: color.clone(),
                                         created_at: reader_core::now_secs(),
@@ -1587,13 +1704,17 @@ impl ReaderApp {
                     // Create correction records for each selected character
                     let (sb, sc, eb, ec) = sel_range;
                     let replace_chars: Vec<char> = self.csc_custom_replace_buf.chars().collect();
-                    for (idx, _, _, block_text, _) in &block_galleys {
-                        if *idx < sb || *idx > eb {
+                    for entry in block_galleys
+                        .iter()
+                        .filter(|entry| entry.key.chapter == self.current_chapter)
+                    {
+                        let idx = entry.key.block;
+                        if idx < sb || idx > eb {
                             continue;
                         }
-                        let block_chars: Vec<char> = block_text.chars().collect();
-                        let start = if *idx == sb { sc } else { 0 };
-                        let end = if *idx == eb {
+                        let block_chars: Vec<char> = entry.text.chars().collect();
+                        let start = if idx == sb { sc } else { 0 };
+                        let end = if idx == eb {
                             ec.min(block_chars.len())
                         } else {
                             block_chars.len()
@@ -1610,7 +1731,7 @@ impl ReaderApp {
                                 continue;
                             }
                             // Insert into csc_cache as Accepted
-                            let key = (self.current_chapter, *idx);
+                            let key = (self.current_chapter, idx);
                             let corrs = self.csc_cache.entry(key).or_default();
                             if let Some(existing) = corrs.iter_mut().find(|c| c.char_offset == pos)
                             {
@@ -1629,7 +1750,7 @@ impl ReaderApp {
                             if let Some(cfg) = &mut self.book_config {
                                 if let Some(rec) = cfg.corrections.iter_mut().find(|r| {
                                     r.chapter == self.current_chapter
-                                        && r.block_idx == *idx
+                                        && r.block_idx == idx
                                         && r.char_offset == pos
                                 }) {
                                     rec.corrected = corrected;
@@ -1638,7 +1759,7 @@ impl ReaderApp {
                                     cfg.corrections
                                         .push(reader_core::library::CorrectionRecord {
                                             chapter: self.current_chapter,
-                                            block_idx: *idx,
+                                            block_idx: idx,
                                             char_offset: pos,
                                             original,
                                             corrected,
@@ -1790,8 +1911,8 @@ impl ReaderApp {
                         for cr in r.iter() {
                             if cr.rect.contains(click_pos) {
                                 self.csc_popup = Some(crate::app::CscPopupInfo {
-                                    chapter: self.current_chapter,
-                                    block_idx: cr.block_idx,
+                                    chapter: cr.key.chapter,
+                                    block_idx: cr.key.block,
                                     char_offset: cr.char_offset,
                                     original: cr.original.clone(),
                                     corrected: cr.corrected.clone(),

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -313,6 +313,7 @@ impl ReaderApp {
                         continuous_chapters.iter().enumerate()
                     {
                         let chapter_idx = start_chapter + offset;
+                        let chapter_top = ui.cursor().top();
                         let chapter_ranges = loaded_highlights.get(&chapter_idx).unwrap_or(
                             if chapter_idx == self.current_chapter {
                                 &highlight_ranges
@@ -345,6 +346,9 @@ impl ReaderApp {
                             &mut clicked_link,
                             chapter_ranges,
                         );
+                        let chapter_height = (ui.cursor().top() - chapter_top).max(0.0);
+                        self.continuous_scroll
+                            .record_height(chapter_idx, chapter_height);
                     }
                     if let Some(target) = self.pending_restore_block {
                         BLOCK_GALLEYS.with(|galleys| {
@@ -366,28 +370,6 @@ impl ReaderApp {
                     scroll_output.content_size.y,
                     viewport.height(),
                 );
-                for chapter_idx in start_chapter..loaded_end {
-                    let height = BLOCK_GALLEYS.with(|galleys| {
-                        let entries = galleys.borrow();
-                        let mut min_y = f32::INFINITY;
-                        let mut max_y = f32::NEG_INFINITY;
-                        for entry in entries
-                            .iter()
-                            .filter(|entry| entry.key.chapter == chapter_idx)
-                        {
-                            min_y = min_y.min(entry.rect.min.y);
-                            max_y = max_y.max(entry.rect.max.y);
-                        }
-                        if min_y.is_finite() && max_y.is_finite() {
-                            Some(max_y - min_y)
-                        } else {
-                            None
-                        }
-                    });
-                    if let Some(height) = height {
-                        self.continuous_scroll.record_height(chapter_idx, height);
-                    }
-                }
                 let visible_block = BLOCK_GALLEYS.with(|galleys| {
                     galleys
                         .borrow()

--- a/desktop/src/ui/reader.rs
+++ b/desktop/src/ui/reader.rs
@@ -260,8 +260,14 @@ impl ReaderApp {
                 {
                     ui.ctx().request_repaint();
                 }
+                if self.continuous_scroll.near_start()
+                    && self.continuous_scroll.prepend_previous().is_some()
+                {
+                    ui.ctx().request_repaint();
+                }
                 let loaded_end = self.continuous_scroll.loaded_end;
                 let start_chapter = self.continuous_scroll.start_chapter;
+                let scroll_adjustment = self.continuous_scroll.take_scroll_adjustment();
                 let continuous_chapters: Vec<(String, Vec<ContentBlock>)> = self
                     .book
                     .as_ref()
@@ -307,6 +313,10 @@ impl ReaderApp {
                 if self.scroll_to_top {
                     scroll_area = scroll_area.vertical_scroll_offset(0.0);
                     self.scroll_to_top = false;
+                } else if scroll_adjustment != 0.0 {
+                    scroll_area = scroll_area.vertical_scroll_offset(
+                        (self.continuous_scroll.scroll_offset + scroll_adjustment).max(0.0),
+                    );
                 }
                 let scroll_output = scroll_area.show(ui, |ui| {
                     for (offset, (chapter_title, chapter_blocks)) in
@@ -404,6 +414,10 @@ impl ReaderApp {
                     < scroll_output.inner_rect.height().max(600.0)
                     && self.continuous_scroll.append_next(total_ch).is_some()
                 {
+                    ui.ctx().request_repaint();
+                }
+                self.continuous_scroll.trim_window();
+                if self.continuous_scroll.start_chapter != start_chapter {
                     ui.ctx().request_repaint();
                 }
             } else {

--- a/desktop/src/ui/reader_block.rs
+++ b/desktop/src/ui/reader_block.rs
@@ -157,7 +157,7 @@ pub(crate) fn render_content_layout(
                             font_family_name,
                             i18n,
                             clicked_link,
-                            abs_idx,
+                            BlockKey::new(current_chapter, abs_idx),
                             hl_ranges,
                         );
                     }
@@ -227,7 +227,7 @@ pub(crate) fn render_block(
     font_family_name: &str,
     i18n: &reader_core::i18n::I18n,
     clicked_link: &mut Option<String>,
-    chapter_block_idx: usize,
+    block_key: BlockKey,
     highlight_ranges: &[(usize, usize, reader_core::library::HighlightColor)],
 ) {
     match block {
@@ -250,7 +250,7 @@ pub(crate) fn render_block(
                 &[],
             );
             ui.add_space(font_size * 0.8);
-            let is_tts_block = TTS_HIGHLIGHT_BLOCK.get() == Some(chapter_block_idx);
+            let is_tts_block = TTS_HIGHLIGHT_BLOCK.get() == Some(block_key);
             let galley = ui.painter().layout_job(job);
             let galley_size = galley.size();
             let (rect, response) =
@@ -264,13 +264,13 @@ pub(crate) fn render_block(
 
             let text: String = spans.iter().map(|span| span.text.as_str()).collect();
             BLOCK_GALLEYS.with(|galleys| {
-                galleys.borrow_mut().push((
-                    chapter_block_idx,
-                    galley.clone(),
+                galleys.borrow_mut().push(BlockGalleyEntry {
+                    key: block_key,
+                    galley: galley.clone(),
                     rect,
                     text,
-                    response.clone(),
-                ));
+                    response: response.clone(),
+                });
             });
 
             // Handle individual link clicks via pointer position matching
@@ -313,7 +313,7 @@ pub(crate) fn render_block(
                     spans.to_vec(),
                     Vec::<(usize, String, String, f32, u8)>::new(),
                 );
-                let corrections = match map.get(&chapter_block_idx) {
+                let corrections = match map.get(&block_key) {
                     Some(c) if !c.is_empty() => c,
                     _ => return empty_result,
                 };
@@ -421,7 +421,7 @@ pub(crate) fn render_block(
             let (rect, response) =
                 ui.allocate_exact_size(galley_size, egui::Sense::click_and_drag());
             // TTS read-along highlight (paint behind text)
-            if TTS_HIGHLIGHT_BLOCK.get() == Some(chapter_block_idx) {
+            if TTS_HIGHLIGHT_BLOCK.get() == Some(block_key) {
                 paint_tts_highlight(ui, rect);
             }
             ui.painter()
@@ -501,7 +501,7 @@ pub(crate) fn render_block(
                             );
                             CSC_RECTS.with(|r| {
                                 r.borrow_mut().push(CscRect {
-                                    block_idx: chapter_block_idx,
+                                    key: block_key,
                                     char_offset,
                                     original: _main_text.clone(), // original text
                                     corrected: top_text.clone(),  // corrected text
@@ -527,13 +527,13 @@ pub(crate) fn render_block(
 
             // Push into per-frame cache for the selection state machine
             BLOCK_GALLEYS.with(|bg| {
-                bg.borrow_mut().push((
-                    chapter_block_idx,
-                    galley.clone(),
+                bg.borrow_mut().push(BlockGalleyEntry {
+                    key: block_key,
+                    galley: galley.clone(),
                     rect,
-                    text.clone(),
-                    response.clone(),
-                ));
+                    text: text.clone(),
+                    response: response.clone(),
+                });
             });
 
             // Handle individual link clicks via pointer position matching

--- a/desktop/src/ui/reader_state.rs
+++ b/desktop/src/ui/reader_state.rs
@@ -44,6 +44,7 @@ pub(crate) struct ContinuousScrollState {
     pub(crate) scroll_offset: f32,
     pub(crate) max_scroll_offset: f32,
     pending_scroll_adjustment: f32,
+    awaiting_prepend_measurement: bool,
     layout_signature: Option<u64>,
     initialized: bool,
 }
@@ -62,6 +63,7 @@ impl ContinuousScrollState {
         self.scroll_offset = 0.0;
         self.max_scroll_offset = 0.0;
         self.layout_signature = None;
+        self.awaiting_prepend_measurement = false;
         self.initialized = true;
     }
 
@@ -88,11 +90,11 @@ impl ContinuousScrollState {
             return None;
         }
         self.start_chapter -= 1;
-        self.pending_scroll_adjustment += self
-            .chapter_heights
-            .get(&self.start_chapter)
-            .copied()
-            .unwrap_or(0.0);
+        if let Some(height) = self.chapter_heights.get(&self.start_chapter).copied() {
+            self.pending_scroll_adjustment += height;
+        } else {
+            self.awaiting_prepend_measurement = true;
+        }
         Some(self.start_chapter)
     }
 
@@ -106,6 +108,15 @@ impl ContinuousScrollState {
             };
             self.pending_scroll_adjustment -= height;
             self.start_chapter += 1;
+        }
+    }
+
+    pub(crate) fn trim_bottom(&mut self) {
+        const MAX_LOADED_CHAPTERS: usize = 4;
+        while self.loaded_end.saturating_sub(self.start_chapter) > MAX_LOADED_CHAPTERS
+            && self.loaded_end > self.visible_chapter + 1
+        {
+            self.loaded_end -= 1;
         }
     }
 
@@ -138,6 +149,10 @@ impl ContinuousScrollState {
     pub(crate) fn record_height(&mut self, chapter: usize, height: f32) {
         if height.is_finite() && height > 0.0 {
             self.chapter_heights.insert(chapter, height);
+            if self.awaiting_prepend_measurement && chapter == self.start_chapter {
+                self.pending_scroll_adjustment += height;
+                self.awaiting_prepend_measurement = false;
+            }
         }
     }
 
@@ -152,7 +167,9 @@ impl ContinuousScrollState {
     }
 
     pub(crate) fn near_start(&self) -> bool {
-        self.scroll_offset <= self.prefetch_distance()
+        !self.awaiting_prepend_measurement
+            && self.scroll_offset <= self.prefetch_distance()
+            && self.visible_chapter > self.start_chapter
     }
 }
 
@@ -518,6 +535,30 @@ mod tests {
         assert_eq!(state.prepend_previous(), Some(1));
         assert_eq!(state.start_chapter, 1);
         assert_eq!(state.take_scroll_adjustment(), 240.0);
+    }
+
+    #[test]
+    fn continuous_scroll_waits_for_prepend_measurement() {
+        let mut state = ContinuousScrollState::default();
+        state.reset(2, 5);
+        state.set_visible_chapter(2);
+        assert_eq!(state.prepend_previous(), Some(1));
+        assert!(!state.near_start());
+        state.record_height(1, 180.0);
+        assert_eq!(state.take_scroll_adjustment(), 180.0);
+        assert!(state.near_start());
+    }
+
+    #[test]
+    fn continuous_scroll_trims_bottom_when_loading_previous() {
+        let mut state = ContinuousScrollState::default();
+        state.reset(2, 8);
+        state.loaded_end = 6;
+        state.set_visible_chapter(2);
+        assert_eq!(state.prepend_previous(), Some(1));
+        state.trim_bottom();
+        assert_eq!(state.start_chapter, 1);
+        assert_eq!(state.loaded_end, 5);
     }
 
     #[test]

--- a/desktop/src/ui/reader_state.rs
+++ b/desktop/src/ui/reader_state.rs
@@ -82,6 +82,15 @@ impl ContinuousScrollState {
         Some(chapter)
     }
 
+    pub(crate) fn near_end(&self) -> bool {
+        self.max_scroll_offset <= 0.0
+            || self.scroll_offset >= self.max_scroll_offset - self.prefetch_distance()
+    }
+
+    fn prefetch_distance(&self) -> f32 {
+        600.0
+    }
+
     pub(crate) fn set_visible_chapter(&mut self, chapter: usize) {
         self.visible_chapter = chapter;
     }
@@ -468,6 +477,10 @@ mod tests {
         state.record_scroll_output(900.0, 1000.0, 400.0);
         assert_eq!(state.max_scroll_offset, 600.0);
         assert_eq!(state.scroll_offset, 600.0);
+        assert!(state.near_end());
+
+        state.record_scroll_output(0.0, 2400.0, 400.0);
+        assert!(!state.near_end());
     }
 
     #[test]

--- a/desktop/src/ui/reader_state.rs
+++ b/desktop/src/ui/reader_state.rs
@@ -168,8 +168,9 @@ impl ContinuousScrollState {
 
     pub(crate) fn near_start(&self) -> bool {
         !self.awaiting_prepend_measurement
+            && self.pending_scroll_adjustment == 0.0
             && self.scroll_offset <= self.prefetch_distance()
-            && self.visible_chapter > self.start_chapter
+            && self.start_chapter > 0
     }
 }
 

--- a/desktop/src/ui/reader_state.rs
+++ b/desktop/src/ui/reader_state.rs
@@ -43,6 +43,7 @@ pub(crate) struct ContinuousScrollState {
     pub(crate) chapter_heights: HashMap<usize, f32>,
     pub(crate) scroll_offset: f32,
     pub(crate) max_scroll_offset: f32,
+    pending_scroll_adjustment: f32,
     layout_signature: Option<u64>,
     initialized: bool,
 }
@@ -82,6 +83,36 @@ impl ContinuousScrollState {
         Some(chapter)
     }
 
+    pub(crate) fn prepend_previous(&mut self) -> Option<usize> {
+        if !self.initialized || self.start_chapter == 0 {
+            return None;
+        }
+        self.start_chapter -= 1;
+        self.pending_scroll_adjustment += self
+            .chapter_heights
+            .get(&self.start_chapter)
+            .copied()
+            .unwrap_or(0.0);
+        Some(self.start_chapter)
+    }
+
+    pub(crate) fn trim_window(&mut self) {
+        const MAX_LOADED_CHAPTERS: usize = 4;
+        while self.loaded_end.saturating_sub(self.start_chapter) > MAX_LOADED_CHAPTERS
+            && self.start_chapter < self.visible_chapter
+        {
+            let Some(height) = self.chapter_heights.get(&self.start_chapter).copied() else {
+                break;
+            };
+            self.pending_scroll_adjustment -= height;
+            self.start_chapter += 1;
+        }
+    }
+
+    pub(crate) fn take_scroll_adjustment(&mut self) -> f32 {
+        std::mem::take(&mut self.pending_scroll_adjustment)
+    }
+
     pub(crate) fn near_end(&self) -> bool {
         self.max_scroll_offset <= 0.0
             || self.scroll_offset >= self.max_scroll_offset - self.prefetch_distance()
@@ -118,6 +149,10 @@ impl ContinuousScrollState {
     ) {
         self.max_scroll_offset = (content_height - viewport_height).max(0.0);
         self.scroll_offset = offset.clamp(0.0, self.max_scroll_offset);
+    }
+
+    pub(crate) fn near_start(&self) -> bool {
+        self.scroll_offset <= self.prefetch_distance()
     }
 }
 
@@ -457,6 +492,32 @@ mod tests {
         assert_eq!(state.append_next(5), Some(3));
         assert_eq!(state.append_next(5), Some(4));
         assert_eq!(state.append_next(5), None);
+    }
+
+    #[test]
+    fn continuous_scroll_keeps_a_bounded_window() {
+        let mut state = ContinuousScrollState::default();
+        state.reset(0, 8);
+        for chapter in 0..4 {
+            state.record_height(chapter, 100.0);
+            assert_eq!(state.append_next(8), Some(chapter + 1));
+        }
+        state.set_visible_chapter(1);
+        state.trim_window();
+
+        assert_eq!(state.start_chapter, 1);
+        assert_eq!(state.loaded_end, 5);
+        assert_eq!(state.take_scroll_adjustment(), -100.0);
+    }
+
+    #[test]
+    fn continuous_scroll_prepending_restores_scroll_anchor() {
+        let mut state = ContinuousScrollState::default();
+        state.reset(2, 5);
+        state.record_height(1, 240.0);
+        assert_eq!(state.prepend_previous(), Some(1));
+        assert_eq!(state.start_chapter, 1);
+        assert_eq!(state.take_scroll_adjustment(), 240.0);
     }
 
     #[test]

--- a/desktop/src/ui/reader_state.rs
+++ b/desktop/src/ui/reader_state.rs
@@ -45,6 +45,7 @@ pub(crate) struct ContinuousScrollState {
     pub(crate) max_scroll_offset: f32,
     pending_scroll_adjustment: f32,
     awaiting_prepend_measurement: bool,
+    suppress_prepend_until_scroll: bool,
     layout_signature: Option<u64>,
     initialized: bool,
 }
@@ -64,6 +65,7 @@ impl ContinuousScrollState {
         self.max_scroll_offset = 0.0;
         self.layout_signature = None;
         self.awaiting_prepend_measurement = false;
+        self.suppress_prepend_until_scroll = true;
         self.initialized = true;
     }
 
@@ -167,10 +169,19 @@ impl ContinuousScrollState {
     }
 
     pub(crate) fn near_start(&self) -> bool {
-        !self.awaiting_prepend_measurement
+        !self.suppress_prepend_until_scroll
+            && !self.awaiting_prepend_measurement
             && self.pending_scroll_adjustment == 0.0
             && self.scroll_offset <= self.prefetch_distance()
             && self.start_chapter > 0
+    }
+
+    pub(crate) fn allow_prepend_after_user_scroll(&mut self, delta_y: f32) {
+        // egui uses a positive wheel delta when the content should move down,
+        // i.e. the user is scrolling toward earlier content.
+        if delta_y > 0.0 {
+            self.suppress_prepend_until_scroll = false;
+        }
     }
 }
 
@@ -547,6 +558,18 @@ mod tests {
         assert!(!state.near_start());
         state.record_height(1, 180.0);
         assert_eq!(state.take_scroll_adjustment(), 180.0);
+        state.allow_prepend_after_user_scroll(24.0);
+        assert!(state.near_start());
+    }
+
+    #[test]
+    fn continuous_scroll_does_not_prepend_after_explicit_positioning() {
+        let mut state = ContinuousScrollState::default();
+        state.reset(3, 6);
+        state.record_scroll_output(0.0, 1200.0, 600.0);
+        assert!(!state.near_start());
+
+        state.allow_prepend_after_user_scroll(24.0);
         assert!(state.near_start());
     }
 

--- a/desktop/src/ui/reader_state.rs
+++ b/desktop/src/ui/reader_state.rs
@@ -2,7 +2,7 @@
 
 use std::cell::Cell;
 use std::cell::RefCell;
-use std::collections::hash_map::DefaultHasher;
+use std::collections::{hash_map::DefaultHasher, HashMap};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -33,21 +33,120 @@ pub(crate) fn text_indent() -> f32 {
     TEXT_INDENT.get()
 }
 
+/// State for the chapter window used by continuous reading mode.
+/// This remains independent from paging state during the incremental rollout.
+#[derive(Debug, Default)]
+pub(crate) struct ContinuousScrollState {
+    pub(crate) start_chapter: usize,
+    pub(crate) loaded_end: usize,
+    pub(crate) visible_chapter: usize,
+    pub(crate) chapter_heights: HashMap<usize, f32>,
+    pub(crate) scroll_offset: f32,
+    pub(crate) max_scroll_offset: f32,
+    layout_signature: Option<u64>,
+    initialized: bool,
+}
+
+impl ContinuousScrollState {
+    pub(crate) fn reset(&mut self, chapter: usize, total_chapters: usize) {
+        if total_chapters == 0 {
+            *self = Self::default();
+            return;
+        }
+        let chapter = chapter.min(total_chapters - 1);
+        self.start_chapter = chapter;
+        self.loaded_end = chapter + 1;
+        self.visible_chapter = chapter;
+        self.chapter_heights.clear();
+        self.scroll_offset = 0.0;
+        self.max_scroll_offset = 0.0;
+        self.layout_signature = None;
+        self.initialized = true;
+    }
+
+    pub(crate) fn needs_reset(&self, current_chapter: usize, total_chapters: usize) -> bool {
+        !self.initialized
+            || total_chapters == 0
+            || self.loaded_end > total_chapters
+            || self.start_chapter >= self.loaded_end
+            || current_chapter < self.start_chapter
+            || current_chapter >= self.loaded_end
+    }
+
+    pub(crate) fn append_next(&mut self, total_chapters: usize) -> Option<usize> {
+        if !self.initialized || self.loaded_end >= total_chapters {
+            return None;
+        }
+        let chapter = self.loaded_end;
+        self.loaded_end += 1;
+        Some(chapter)
+    }
+
+    pub(crate) fn set_visible_chapter(&mut self, chapter: usize) {
+        self.visible_chapter = chapter;
+    }
+
+    pub(crate) fn update_layout_signature(&mut self, signature: u64) -> bool {
+        let changed = self.layout_signature.is_some_and(|old| old != signature);
+        if changed {
+            self.chapter_heights.clear();
+        }
+        self.layout_signature = Some(signature);
+        changed
+    }
+
+    pub(crate) fn record_height(&mut self, chapter: usize, height: f32) {
+        if height.is_finite() && height > 0.0 {
+            self.chapter_heights.insert(chapter, height);
+        }
+    }
+
+    pub(crate) fn record_scroll_output(
+        &mut self,
+        offset: f32,
+        content_height: f32,
+        viewport_height: f32,
+    ) {
+        self.max_scroll_offset = (content_height - viewport_height).max(0.0);
+        self.scroll_offset = offset.clamp(0.0, self.max_scroll_offset);
+    }
+}
+
 // ── Thread-local deferred actions & per-frame block galley cache ──
 
-/// Per-frame cache entry: (block_idx, galley, screen_rect, plain_text)
-pub(crate) type BlockGalleyEntry = (usize, Arc<egui::Galley>, egui::Rect, String, egui::Response);
+/// A block identifier that remains unique when multiple chapters share a scroll area.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct BlockKey {
+    pub(crate) chapter: usize,
+    pub(crate) block: usize,
+}
+
+impl BlockKey {
+    pub(crate) const fn new(chapter: usize, block: usize) -> Self {
+        Self { chapter, block }
+    }
+}
+
+/// Per-frame cache entry used by selection, context menus, and position tracking.
+#[derive(Clone)]
+pub(crate) struct BlockGalleyEntry {
+    pub(crate) key: BlockKey,
+    pub(crate) galley: Arc<egui::Galley>,
+    pub(crate) rect: egui::Rect,
+    pub(crate) text: String,
+    pub(crate) response: egui::Response,
+}
 
 pub(crate) type CscCharMapCacheData = (u64, u32, u32, Vec<usize>);
 
 thread_local! {
     /// Collected during render_block, consumed by render_reader for selection state machine.
     pub(crate) static BLOCK_GALLEYS: RefCell<Vec<BlockGalleyEntry>> = const { RefCell::new(Vec::new()) };
-    /// TTS read-along highlight: Some(block_idx) when TTS is actively reading a block.
-    pub(crate) static TTS_HIGHLIGHT_BLOCK: Cell<Option<usize>> = const { Cell::new(None) };
-    /// CSC corrections for the current chapter: block_idx → Vec<CorrectionInfo>.
+    /// TTS read-along highlight for the chapter and block currently being read.
+    pub(crate) static TTS_HIGHLIGHT_BLOCK: Cell<Option<BlockKey>> = const { Cell::new(None) };
+    /// CSC corrections keyed by chapter and block.
     /// Set before rendering, read inside render_block for Ruby annotation painting.
-    pub(crate) static CSC_CORRECTIONS: RefCell<std::collections::HashMap<usize, Vec<reader_core::epub::CorrectionInfo>>>
+    pub(crate) static CSC_CORRECTIONS: RefCell<std::collections::HashMap<BlockKey, Vec<reader_core::epub::CorrectionInfo>>>
         = RefCell::new(std::collections::HashMap::new());
     /// Whether ReadWrite mode is active (enables click-on-correction popups).
     pub(crate) static CSC_READWRITE: Cell<bool> = const { Cell::new(false) };
@@ -59,7 +158,7 @@ thread_local! {
 
 /// A clickable correction rect collected during rendering.
 pub(crate) struct CscRect {
-    pub(crate) block_idx: usize,
+    pub(crate) key: BlockKey,
     pub(crate) char_offset: usize,
     pub(crate) original: String,
     pub(crate) corrected: String,
@@ -338,6 +437,38 @@ pub(crate) fn normalize_epub_href(href: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn continuous_scroll_loads_chapters_incrementally() {
+        let mut state = ContinuousScrollState::default();
+        state.reset(2, 5);
+
+        assert_eq!(state.start_chapter, 2);
+        assert_eq!(state.loaded_end, 3);
+        assert_eq!(state.append_next(5), Some(3));
+        assert_eq!(state.append_next(5), Some(4));
+        assert_eq!(state.append_next(5), None);
+    }
+
+    #[test]
+    fn continuous_scroll_invalidates_measured_heights_on_layout_change() {
+        let mut state = ContinuousScrollState::default();
+        state.reset(0, 2);
+        assert!(!state.update_layout_signature(10));
+        state.record_height(0, 1200.0);
+        assert!(!state.update_layout_signature(10));
+        assert!(state.update_layout_signature(11));
+        assert!(state.chapter_heights.is_empty());
+    }
+
+    #[test]
+    fn continuous_scroll_clamps_scroll_output() {
+        let mut state = ContinuousScrollState::default();
+        state.reset(0, 2);
+        state.record_scroll_output(900.0, 1000.0, 400.0);
+        assert_eq!(state.max_scroll_offset, 600.0);
+        assert_eq!(state.scroll_offset, 600.0);
+    }
 
     #[test]
     fn dual_column_scales_on_4k_width() {


### PR DESCRIPTION
# Pull Request 模板

## 分类

- [ ] BUG 修复（bug）
- [x] 新功能（enhancement）
- [ ] 文档（documentation）
- [ ] 更新/优化（update）

## 变更内容概述

这是 #39 的替代实现，基于当前 `main` 重新设计连续章节滚动，而不是直接解决原 PR 的冲突：

- 使用独立 `ContinuousScrollState` 管理章节窗口、加载边界、布局签名和滚动状态；
- 使用 `BlockKey { chapter, block }` 统一跨章节 block 标识，避免不同章节相同 block index 相互污染；
- 在同一 `ScrollArea` 中渐进加载当前章节及后续章节，接近底部时追加下一章；
- 阅读位置保存升级为 `chapter + block`；
- 已加载章节统一适配高亮、CSC correction、选择、TTS 状态和 block galley 缓存；
- 跨章节分页动画快照保留真实章节标识；
- 保留分页/双栏模式以及 #40、#41、#42 已合并行为。

当前采用“有限章节窗口 + 接近底部增量追加”，尚未引入按可见区域卸载 block 的完整虚拟化。

## 相关 Issue（可选）

- 替代 #39 的实现思路；原 #39 暂时保持开放，待本 PR 审阅和 UI 回归后再决定是否关闭。

## 影响平台

- [x] Desktop (Windows / macOS / Linux)
- [ ] Android
- [ ] Core / EPUB 解析 / 搜索 / 分享
- [x] CSC 校对 / 模型加载
- [ ] CI / Release / 构建脚本
- [ ] 文档 / 示例

## 验证方式

- [x] 已运行 `cargo fmt --all -- --check`
- [ ] 已运行 `cargo clippy --all-targets --all-features -- -D warnings`（Windows 环境缺少 Perl，vendored `openssl-sys` 无法构建）
- [x] 已运行 `cargo check -p rust_epub_reader --all-targets`
- [x] 已运行 `cargo test -p rust_epub_reader`（21 项通过）
- [x] 已运行 `git diff --check`
- [ ] 如修改 Android，已运行 `./gradlew :app:assembleRelease` 或相关 Gradle 检查
- [ ] 如修改发布流程，已检查 workflow YAML 与产物路径

## 兼容性/风险评估

- [x] 无破坏性变更
- [ ] 需要文档更新
- [ ] 配置/依赖有变更
- [ ] 涉及书库/设置/本地数据结构变更

合并前建议人工验证：长章节、触控板惯性滚动、窗口 resize、目录/搜索/书签/标注跳转，以及 TTS 跟随阅读的组合场景。