### PR TITLE
[Update] 更新: 升级 Android Gradle 构建工具

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.application") version "9.2.1" apply false
-    id("com.android.library") version "9.2.1" apply false
+    id("com.android.application") version "9.3.1" apply false
+    id("com.android.library") version "9.3.1" apply false
     id("org.jetbrains.kotlin.android") version "2.2.10" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.10" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.2.10" apply false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Pull Request 模板

## 分类

- [ ] BUG 修复（bug）
- [ ] 新功能（enhancement）
- [ ] 文档（documentation）
- [x] 更新/优化（update）

## 变更内容概述

补充提交合并 #44 时仍留在本地、尚未进入 `main` 的 Android 构建工具升级：

- Android Gradle Plugin：`9.2.1` → `9.3.1`
- Gradle Wrapper：`9.4.1` → `9.5.0`

## 相关 Issue（可选）

- #44 后续补充

## 影响平台

- [ ] Desktop (Windows / macOS / Linux)
- [x] Android
- [ ] Core / EPUB 解析 / 搜索 / 分享
- [ ] CSC 校对 / 模型加载
- [x] CI / Release / 构建脚本
- [ ] 文档 / 示例

## 验证方式

- [x] 已运行 `./gradlew :app:compileDebugKotlin :app:lintVitalRelease --stacktrace`
- [ ] 已运行 `cargo fmt --all -- --check`
- [ ] 已运行 `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] 已运行 `cargo test --all --all-features`
- [x] 如修改 Android，已运行相关 Gradle 检查
- [ ] 如修改发布流程，已检查 workflow YAML 与产物路径

## 兼容性/风险评估

- [x] 无破坏性变更
- [ ] 需要文档更新
- [x] 配置/依赖有变更
- [ ] 涉及书库/设置/本地数据结构变更